### PR TITLE
Fix WindowExt derive macro compiler error

### DIFF
--- a/fltk-derive/src/window.rs
+++ b/fltk-derive/src/window.rs
@@ -153,7 +153,7 @@ pub fn impl_window_trait(ast: &DeriveInput) -> TokenStream {
                         target_os = "netbsd",
                         target_os = "openbsd",
                     ))]
-                    return winid.x_id;
+                    return winid.x_id as RawHandle;
                 }
             }
 


### PR DESCRIPTION
Was missing a cast, causing the error on architectures where long is not 64 bits.

Potentially fixes #252