### PR TITLE
0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.10.3] - Unreleased
 ### Changes
 - Change return type of Printer::begin_job().
+- Use AtomicUsize for refcounting instead of Arc<Mutex>.
 
 ## [0.10.3] - 2020-11-04
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.10.4] - Unreleased
+## [0.10.4] - 2020-11-06
 ### Changes
 - Change return type of Printer::begin_job().
 - Use AtomicUsize for refcounting instead of Arc<Mutex>.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Change return type of Printer::begin_job().
 - Use AtomicUsize for refcounting instead of Arc<Mutex>.
 - Decrease refcount when unsetting an image or setting another image.
+- Remove unwrapping when querying for windows, which could fail.
 
 ## [0.10.3] - 2020-11-04
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.10.3] - Unreleased
+## [0.10.4] - Unreleased
 ### Changes
 - Change return type of Printer::begin_job().
 - Use AtomicUsize for refcounting instead of Arc<Mutex>.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.10.3] - Unreleased
+### Changes
+- Change return type of Printer::begin_job().
+
 ## [0.10.3] - 2020-11-04
 ### Changes
 - BREAKING (Security update): Methods and functions returning widget and image instances now return a safer boxed trait object since these might not be constructed by user code (like in dialogs).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changes
 - Change return type of Printer::begin_job().
 - Use AtomicUsize for refcounting instead of Arc<Mutex>.
+- Decrease refcount when unsetting an image or setting another image.
 
 ## [0.10.3] - 2020-11-04
 ### Changes

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/browser.rs
+++ b/fltk-derive/src/browser.rs
@@ -264,6 +264,7 @@ pub fn impl_browser_trait(ast: &DeriveInput) -> TokenStream {
             fn set_icon<Img: ImageExt>(&mut self, line: u32, image: Option<Img>) {
                 assert!(!self.was_deleted());
                 debug_assert!(line <= std::isize::MAX as u32, "u32 entries have to be < std::isize::MAX for compatibility!");
+                let _old_image = self.image();
                 if let Some(mut image) = image {
                     assert!(!image.was_deleted());
                     unsafe { image.increment_arc(); #set_icon(self._inner, line as i32, image.as_image_ptr() as *mut _) }

--- a/fltk-derive/src/display.rs
+++ b/fltk-derive/src/display.rs
@@ -237,7 +237,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
                 unsafe {
                     assert!(!self.was_deleted());
                     if let Some(buffer) = buffer {
-                        *buffer._refcount.lock().unwrap() += 1;
+                        buffer._refcount.fetch_add(1, Ordering::Relaxed);
                         #set_buffer(self._inner, buffer.as_ptr())
                     } else {
                         #set_buffer(self._inner, std::ptr::null_mut() as *mut Fl_Text_Buffer)
@@ -415,7 +415,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
                 assert!(!self.was_deleted());
                 assert!(self.buffer().is_some());
                 assert!(entries.len() < 29);
-                *style_buffer._refcount.lock().unwrap() += 1;
+                style_buffer._refcount.fetch_add(1, Ordering::Relaxed);
                 let mut colors: Vec<u32> = vec![];
                 let mut fonts: Vec<i32> = vec![];
                 let mut sizes: Vec<i32> = vec![];

--- a/fltk-derive/src/display.rs
+++ b/fltk-derive/src/display.rs
@@ -236,6 +236,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
             fn set_buffer(&mut self, buffer: Option<TextBuffer>) {
                 unsafe {
                     assert!(!self.was_deleted());
+                    let _old_buf = self.buffer();
                     if let Some(buffer) = buffer {
                         buffer._refcount.fetch_add(1, Ordering::Relaxed);
                         #set_buffer(self._inner, buffer.as_ptr())
@@ -415,6 +416,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
                 assert!(!self.was_deleted());
                 assert!(self.buffer().is_some());
                 assert!(entries.len() < 29);
+                let _old_buf = self.buffer();
                 style_buffer._refcount.fetch_add(1, Ordering::Relaxed);
                 let mut colors: Vec<u32> = vec![];
                 let mut fonts: Vec<i32> = vec![];

--- a/fltk-derive/src/image.rs
+++ b/fltk-derive/src/image.rs
@@ -212,6 +212,11 @@ pub fn impl_image_trait(ast: &DeriveInput) -> TokenStream {
                 self._refcount.fetch_add(1, Ordering::Relaxed);
             }
 
+            unsafe fn decrement_arc(&mut self) {
+                assert!(!self.was_deleted());
+                self._refcount.fetch_sub(1, Ordering::Relaxed);
+            }
+
             fn was_deleted(&self) -> bool {
                 self._inner.is_null()
             }

--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -904,6 +904,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
 
             fn set_image<I: ImageExt>(&mut self, image: Option<I>) {
                 assert!(!self.was_deleted());
+                let _old_image = self.image();
                 if let Some(mut image) = image {
                     assert!(!image.was_deleted());
                     unsafe { image.increment_arc(); #set_image(self._inner, image.as_image_ptr() as *mut _) }
@@ -926,6 +927,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
 
             fn set_deimage<I: ImageExt>(&mut self, image: Option<I>) {
                 assert!(!self.was_deleted());
+                let _old_image = self.image();
                 if let Some(mut image) = image {
                     assert!(!image.was_deleted());
                     unsafe { image.increment_arc(); #set_deimage(self._inner, image.as_image_ptr() as *mut _) }

--- a/fltk-derive/src/window.rs
+++ b/fltk-derive/src/window.rs
@@ -92,6 +92,7 @@ pub fn impl_window_trait(ast: &DeriveInput) -> TokenStream {
             fn set_icon<T: ImageExt>(&mut self, image: Option<T>) {
                 assert!(!self.was_deleted());
                 assert!(std::any::type_name::<T>() != std::any::type_name::<crate::image::SharedImage>(), "SharedImage icons are not supported!");
+                let _old_image = self.image();
                 if let Some(mut image) = image {
                     assert!(!image.was_deleted());
                     unsafe { image.increment_arc(); #set_icon(self._inner, image.as_image_ptr() as *mut _) }

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "^0.10.3" }
-fltk-derive = { path = "../fltk-derive", version = "^0.10.3" }
+fltk-sys = { path = "../fltk-sys", version = "^0.10.4" }
+fltk-derive = { path = "../fltk-derive", version = "^0.10.4" }
 
 [features]
 default = []

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -9,7 +9,7 @@ use std::{
     ffi::{CStr, CString},
     marker, mem,
     os::raw,
-    panic, path, process, ptr, time,
+    panic, path, ptr, time,
 };
 
 pub type WidgetPtr = *mut fltk_sys::widget::Fl_Widget;
@@ -219,7 +219,7 @@ impl App {
     }
 
     /// Quit the application
-    pub fn quit(&self) -> ! {
+    pub fn quit(&self) {
         quit()
     }
 }
@@ -617,7 +617,7 @@ pub fn next_window<W: WindowExt>(w: &W) -> Option<impl WindowExt> {
 }
 
 /// Quit the app
-pub fn quit() -> ! {
+pub fn quit() {
     unsafe {
         if let Some(loaded_font) = LOADED_FONT {
             // Shouldn't fail
@@ -631,7 +631,6 @@ pub fn quit() -> ! {
             }
         }
     }
-    process::exit(0);
 }
 
 /// Adds a one-shot timeout callback. The timeout duration `tm` is indicated in seconds

--- a/fltk/src/image.rs
+++ b/fltk/src/image.rs
@@ -3,21 +3,21 @@ use fltk_sys::image::*;
 use std::{
     ffi::CString,
     mem,
-    sync::{Arc, Mutex},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 /// Wrapper around Fl_Image, used to wrap other image types
 #[derive(ImageExt, Debug)]
 pub struct Image {
     _inner: *mut Fl_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 /// Creates a struct holding a shared image
 #[derive(ImageExt, Debug)]
 pub struct SharedImage {
     _inner: *mut Fl_Shared_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl SharedImage {
@@ -44,7 +44,7 @@ impl SharedImage {
                 }
                 Ok(SharedImage {
                     _inner: x,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -62,7 +62,7 @@ impl SharedImage {
                 }
                 Ok(SharedImage {
                     _inner: x,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -73,7 +73,7 @@ impl SharedImage {
 #[derive(ImageExt, Debug)]
 pub struct JpegImage {
     _inner: *mut Fl_JPEG_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl JpegImage {
@@ -100,7 +100,7 @@ impl JpegImage {
                 }
                 Ok(JpegImage {
                     _inner: image_ptr,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -121,7 +121,7 @@ impl JpegImage {
                     }
                     Ok(JpegImage {
                         _inner: x,
-                        _refcount: Arc::from(Mutex::from(1)),
+                        _refcount: AtomicUsize::new(1),
                     })
                 }
             }
@@ -142,7 +142,7 @@ impl JpegImage {
 #[derive(ImageExt, Debug)]
 pub struct PngImage {
     _inner: *mut Fl_PNG_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl PngImage {
@@ -169,7 +169,7 @@ impl PngImage {
                 }
                 Ok(PngImage {
                     _inner: image_ptr,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -190,7 +190,7 @@ impl PngImage {
                     }
                     Ok(PngImage {
                         _inner: x,
-                        _refcount: Arc::from(Mutex::from(1)),
+                        _refcount: AtomicUsize::new(1),
                     })
                 }
             }
@@ -211,7 +211,7 @@ impl PngImage {
 #[derive(ImageExt, Debug)]
 pub struct SvgImage {
     _inner: *mut Fl_SVG_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl SvgImage {
@@ -238,7 +238,7 @@ impl SvgImage {
                 }
                 Ok(SvgImage {
                     _inner: image_ptr,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -260,7 +260,7 @@ impl SvgImage {
                     }
                     Ok(SvgImage {
                         _inner: x,
-                        _refcount: Arc::from(Mutex::from(1)),
+                        _refcount: AtomicUsize::new(1),
                     })
                 }
             }
@@ -272,7 +272,7 @@ impl SvgImage {
 #[derive(ImageExt, Debug)]
 pub struct BmpImage {
     _inner: *mut Fl_BMP_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl BmpImage {
@@ -299,7 +299,7 @@ impl BmpImage {
                 }
                 Ok(BmpImage {
                     _inner: image_ptr,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -320,7 +320,7 @@ impl BmpImage {
                     }
                     Ok(BmpImage {
                         _inner: x,
-                        _refcount: Arc::from(Mutex::from(1)),
+                        _refcount: AtomicUsize::new(1),
                     })
                 }
             }
@@ -341,7 +341,7 @@ impl BmpImage {
 #[derive(ImageExt, Debug)]
 pub struct GifImage {
     _inner: *mut Fl_GIF_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl GifImage {
@@ -368,7 +368,7 @@ impl GifImage {
                 }
                 Ok(GifImage {
                     _inner: image_ptr,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -389,7 +389,7 @@ impl GifImage {
                     }
                     Ok(GifImage {
                         _inner: x,
-                        _refcount: Arc::from(Mutex::from(1)),
+                        _refcount: AtomicUsize::new(1),
                     })
                 }
             }
@@ -401,7 +401,7 @@ impl GifImage {
 #[derive(ImageExt, Debug)]
 pub struct XpmImage {
     _inner: *mut Fl_XPM_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl XpmImage {
@@ -428,7 +428,7 @@ impl XpmImage {
                 }
                 Ok(XpmImage {
                     _inner: image_ptr,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -439,7 +439,7 @@ impl XpmImage {
 #[derive(ImageExt, Debug)]
 pub struct XbmImage {
     _inner: *mut Fl_XBM_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl XbmImage {
@@ -466,7 +466,7 @@ impl XbmImage {
                 }
                 Ok(XbmImage {
                     _inner: image_ptr,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -477,7 +477,7 @@ impl XbmImage {
 #[derive(ImageExt, Debug)]
 pub struct PnmImage {
     _inner: *mut Fl_PNM_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl PnmImage {
@@ -504,7 +504,7 @@ impl PnmImage {
                 }
                 Ok(PnmImage {
                     _inner: image_ptr,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -515,7 +515,7 @@ impl PnmImage {
 #[derive(ImageExt, Debug)]
 pub struct TiledImage {
     _inner: *mut Fl_Tiled_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl TiledImage {
@@ -526,7 +526,7 @@ impl TiledImage {
             assert!(!ptr.is_null());
             TiledImage {
                 _inner: ptr,
-                _refcount: Arc::from(Mutex::from(1)),
+                _refcount: AtomicUsize::new(1),
             }
         }
     }
@@ -536,7 +536,7 @@ impl TiledImage {
 #[derive(ImageExt, Debug)]
 pub struct Pixmap {
     _inner: *mut Fl_Pixmap,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl Pixmap {
@@ -549,7 +549,7 @@ impl Pixmap {
             assert!(!ptr.is_null());
             Pixmap {
                 _inner: ptr,
-                _refcount: Arc::from(Mutex::from(1)),
+                _refcount: AtomicUsize::new(1),
             }
         }
     }
@@ -559,7 +559,7 @@ impl Pixmap {
 #[derive(ImageExt, Debug)]
 pub struct RgbImage {
     _inner: *mut Fl_RGB_Image,
-    _refcount: Arc<Mutex<usize>>,
+    _refcount: AtomicUsize,
 }
 
 impl RgbImage {
@@ -590,7 +590,7 @@ impl RgbImage {
             } else {
                 Ok(RgbImage {
                     _inner: img,
-                    _refcount: Arc::from(Mutex::from(1)),
+                    _refcount: AtomicUsize::new(1),
                 })
             }
         }
@@ -621,7 +621,7 @@ impl RgbImage {
         } else {
             Ok(RgbImage {
                 _inner: img,
-                _refcount: Arc::from(Mutex::from(1)),
+                _refcount: AtomicUsize::new(1),
             })
         }
     }

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -1049,6 +1049,10 @@ pub unsafe trait ImageExt {
     /// # Safety
     /// The underlying image pointer must be valid
     unsafe fn increment_arc(&mut self);
+    /// INTERNAL: Manually decrement the atomic refcount
+    /// # Safety
+    /// The underlying image pointer must be valid
+    unsafe fn decrement_arc(&mut self);
     /// Transforms an Image base into another Image
     /// # Safety
     /// Can be unsafe if used to downcast to an image of different format

--- a/fltk/src/printer.rs
+++ b/fltk/src/printer.rs
@@ -19,7 +19,11 @@ impl Printer {
     /// Begins a print job
     /// `pagecount` The total number of pages to be created. Use 0 if this number is unknown
     /// Returns a tuple (frompage, topage) indicating the chosen pages by the user
-    pub fn begin_job(&mut self, pagecount: u32) -> Result<(Option<i32>, Option<i32>), FltkError> {
+    pub fn begin_job(&mut self, pagecount: u32) -> Result<(Option<u32>, Option<u32>), FltkError> {
+        debug_assert!(
+            pagecount <= std::isize::MAX as u32,
+            "u32 entries have to be < std::isize::MAX for compatibility!"
+        );
         let frompage_: *mut i32 = std::ptr::null_mut();
         let topage_: *mut i32 = std::ptr::null_mut();
         unsafe {
@@ -36,12 +40,12 @@ impl Printer {
                 let from = if frompage_.is_null() {
                     None
                 } else {
-                    Some(*frompage_)
+                    Some(*frompage_ as u32)
                 };
                 let to = if topage_.is_null() {
                     None
                 } else {
-                    Some(*topage_)
+                    Some(*topage_ as u32)
                 };
                 Ok((from, to))
             }

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -849,6 +849,7 @@ impl Tree {
     /// Sets the user icon
     pub fn set_user_icon<Img: ImageExt>(&mut self, image: Option<Img>) {
         assert!(!self.was_deleted());
+        let _old_image = self.image();
         if let Some(mut image) = image {
             assert!(!image.was_deleted());
             unsafe {
@@ -878,6 +879,7 @@ impl Tree {
     /// Sets the opne icon
     pub fn set_open_icon<Img: ImageExt>(&mut self, image: Option<Img>) {
         assert!(!self.was_deleted());
+        let _old_image = self.image();
         if let Some(mut image) = image {
             assert!(!image.was_deleted());
             unsafe {
@@ -907,6 +909,7 @@ impl Tree {
     /// Sets the opne icon
     pub fn set_close_icon<Img: ImageExt>(&mut self, image: Option<Img>) {
         assert!(!self.was_deleted());
+        let _old_image = self.image();
         if let Some(mut image) = image {
             assert!(!image.was_deleted());
             unsafe {


### PR DESCRIPTION
- Change return type of Printer::begin_job().
- Use AtomicUsize for refcounting instead of Arc<Mutex>.
- Decrease refcount when unsetting an image or setting another image.
- Remove unwrapping when querying for windows, which could fail.