### PR TITLE
0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.10.5] - Unreleased
+## [0.10.5] - 2020-11-08
 ### Changes
 - Patch fltk to fix behavior of Fl_Win32_At_Exit() with mingw toolchain.
 - Fix android build which doesn't support Fl_Printer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Patch fltk to fix behavior of Fl_Win32_At_Exit() with mingw toolchain.
 - Fix android build which doesn't support Fl_Printer.
 - Fix WidgetExt::with_size() resizability.
+- Add WidgetExt::measure_label() and draw::measure().
 
 ## [0.10.4] - 2020-11-06
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.10.5] - Unreleased
+### Changes
+- Patch fltk to fix behavior of Fl_Win32_At_Exit() with mingw toolchain.
+
 ## [0.10.4] - 2020-11-06
 ### Changes
 - Change return type of Printer::begin_job().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.10.4] - Unreleased
+## [0.10.4] - 2020-11-06
 ### Changes
 - Change return type of Printer::begin_job().
 - Use AtomicUsize for refcounting instead of Arc<Mutex>.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changes
 - Patch fltk to fix behavior of Fl_Win32_At_Exit() with mingw toolchain.
 - Fix android build which doesn't support Fl_Printer.
+- Fix WidgetExt::with_size() resizability.
 
 ## [0.10.4] - 2020-11-06
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.10.5] - Unreleased
 ### Changes
 - Patch fltk to fix behavior of Fl_Win32_At_Exit() with mingw toolchain.
+- Fix android build which doesn't support Fl_Printer.
 
 ## [0.10.4] - 2020-11-06
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix android build which doesn't support Fl_Printer.
 - Fix WidgetExt::with_size() resizability.
 - Add WidgetExt::measure_label() and draw::measure().
+- Simplified some return types in the printer module.
 
 ## [0.10.4] - 2020-11-06
 ### Changes

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.10.4"
+version = "0.10.5"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -223,6 +223,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
     let width = Ident::new(format!("{}_{}", name_str, "width").as_str(), name.span());
     let height = Ident::new(format!("{}_{}", name_str, "height").as_str(), name.span());
     let label = Ident::new(format!("{}_{}", name_str, "label").as_str(), name.span());
+    let measure_label = Ident::new(format!("{}_{}", name_str, "measure_label").as_str(), name.span());
     let set_label = Ident::new(
         format!("{}_{}", name_str, "set_label").as_str(),
         name.span(),
@@ -468,6 +469,16 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
                 unsafe {
                     CStr::from_ptr(#label(self._inner) as *mut raw::c_char).to_string_lossy().to_string()
                 }
+            }
+
+            fn measure_label(&self) -> (i32, i32) {
+                assert!(!self.was_deleted());
+                let mut x = 0;
+                let mut y = 0;
+                unsafe {
+                    #measure_label(self._inner, &mut x, &mut y);
+                }
+                (x, y)
             }
 
             unsafe fn as_widget_ptr(&self) -> *mut fltk_sys::widget::Fl_Widget {
@@ -879,7 +890,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
                 let y = self.y();
                 let w = self.width();
                 let h = self.height();
-                if w == 0 && h == 0 {
+                if w == 0 || h == 0 {
                     unsafe { #widget_resize(self._inner, x, y, width, height); }
                 } else {
                     self.resize(x, y, width, height);

--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -65,22 +65,17 @@ pub fn impl_widget_base_trait(ast: &DeriveInput) -> TokenStream {
             fn default() -> Self {
                 let temp = CString::new("").unwrap();;
                 unsafe {
-                    let widget_ptr = #new(
-                        0,
-                        0,
-                        0,
-                        0,
-                        temp.into_raw());
-                        assert!(!widget_ptr.is_null());
-                        let tracker = fltk_sys::fl::Fl_Widget_Tracker_new(widget_ptr as *mut fltk_sys::fl::Fl_Widget);
-                        assert!(!tracker.is_null());
-                        unsafe extern "C" fn shim(data: *mut raw::c_void) {
-                            if !data.is_null() {
-                                let x = data as *mut Box<dyn FnMut()>;
-                                let x = Box::from_raw(x);
-                            }
+                    let widget_ptr = #new(0, 0, 0, 0, temp.into_raw());
+                    assert!(!widget_ptr.is_null());
+                    let tracker = fltk_sys::fl::Fl_Widget_Tracker_new(widget_ptr as *mut fltk_sys::fl::Fl_Widget);
+                    assert!(!tracker.is_null());
+                    unsafe extern "C" fn shim(data: *mut raw::c_void) {
+                        if !data.is_null() {
+                            let x = data as *mut Box<dyn FnMut()>;
+                            let x = Box::from_raw(x);
                         }
-                        #set_deleter(widget_ptr, Some(shim));
+                    }
+                    #set_deleter(widget_ptr, Some(shim));
                     #name {
                         _inner: widget_ptr,
                         _tracker: tracker,
@@ -245,6 +240,10 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
         name.span(),
     );
     let resize = Ident::new(format!("{}_{}", name_str, "resize").as_str(), name.span());
+    let widget_resize = Ident::new(
+        format!("{}_{}", name_str, "widget_resize").as_str(),
+        name.span(),
+    );
     let tooltip = Ident::new(format!("{}_{}", name_str, "tooltip").as_str(), name.span());
     let set_tooltip = Ident::new(
         format!("{}_{}", name_str, "set_tooltip").as_str(),
@@ -876,7 +875,15 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
             }
 
             fn with_size(mut self, width: i32, height: i32) -> Self {
-                self.resize(self.x(), self.y(), width, height);
+                let x = self.x();
+                let y = self.y();
+                let w = self.width();
+                let h = self.height();
+                if w == 0 && h == 0 {
+                    unsafe { #widget_resize(self._inner, x, y, width, height); }
+                } else {
+                    self.resize(x, y, width, height);
+                }
                 self
             }
 

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.10.4"
+version = "0.10.5"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"

--- a/fltk-sys/cfltk/CMakeLists.txt
+++ b/fltk-sys/cfltk/CMakeLists.txt
@@ -53,8 +53,11 @@ set(CFLTK_SRCS
     src/cfl_table.cpp
     src/cfl_tree.cpp
     src/cfl_surface.cpp
-    src/cfl_printer.cpp
     )
+
+if(NOT ANDROID)
+    set(CFLTK_SRCS ${CFLTK_SRCS} src/cfl_printer.cpp)
+endif()
 
 if(CFLTK_BUILD_SHARED)
     add_library(cfltk SHARED ${CFLTK_SRCS})

--- a/fltk-sys/cfltk/CMakeLists.txt
+++ b/fltk-sys/cfltk/CMakeLists.txt
@@ -89,7 +89,6 @@ if(USE_SYSTEM_FLTK)
         )
 endif()
 
-
 if(CFLTK_BUILD_TESTS)
     enable_testing()
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_INSTALL_PREFIX}/tests)

--- a/fltk-sys/cfltk/fltk.patch
+++ b/fltk-sys/cfltk/fltk.patch
@@ -18,7 +18,7 @@ index 6e8bc5dd6..c3d01df9a 100644
  
  add_subdirectory(src)
 diff --git a/CMake/options.cmake b/CMake/options.cmake
-index ac7fa5bb6..aeb953e99 100644
+index 2bb439ae6..a7259b0f0 100644
 --- a/CMake/options.cmake
 +++ b/CMake/options.cmake
 @@ -115,7 +115,7 @@ option (OPTION_BUILD_SHARED_LIBS
@@ -38,7 +38,7 @@ index 88c5fb891..000000000
 @@ -1 +0,0 @@
 -1.4.0
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index d5eee5dc8..96108dad5 100644
+index ff15cf04a..791c8add8 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -300,6 +300,7 @@ elseif (ANDROID)
@@ -114,6 +114,23 @@ index a98be46ec..07999a0a0 100644
  
  
  
+diff --git a/src/Fl_win32.cxx b/src/Fl_win32.cxx
+index e0d5c9f4b..4f0001c17 100644
+--- a/src/Fl_win32.cxx
++++ b/src/Fl_win32.cxx
+@@ -586,9 +586,11 @@ public:
+   Fl_Win32_At_Exit() {}
+   ~Fl_Win32_At_Exit() {
+     fl_free_fonts(); // do some Windows cleanup
++  #ifndef __MINGW32__
+     fl_cleanup_pens();
+-    OleUninitialize();
+     if (fl_graphics_driver) fl_brush_action(1);
++  #endif
++    OleUninitialize();
+     fl_cleanup_dc_list();
+     // This is actually too late in the cleanup process to remove the
+     // clipboard notifications, but we have no earlier hook so we try
 diff --git a/src/config_lib.h b/src/config_lib.h
 index bbcfb75f5..aa16cd48b 100644
 --- a/src/config_lib.h

--- a/fltk-sys/cfltk/include/cfl_widget.h
+++ b/fltk-sys/cfltk/include/cfl_widget.h
@@ -35,6 +35,7 @@ typedef void (*custom_draw_callback2)(Fl_Widget *, void *);
     void widget##_deactivate(widget *);                                                            \
     void widget##_redraw_label(widget *);                                                          \
     void widget##_resize(widget *, int x, int y, int width, int height);                           \
+    void widget##_widget_resize(widget *, int x, int y, int width, int height);                    \
     const char *widget##_tooltip(widget *);                                                        \
     void widget##_set_tooltip(widget *, const char *txt);                                          \
     int widget##_get_type(widget *);                                                               \
@@ -113,6 +114,10 @@ typedef void (*custom_draw_callback2)(Fl_Widget *, void *);
         }                                                                                          \
         operator widget *() {                                                                      \
             return (widget *)this;                                                                 \
+        }                                                                                          \
+        void widget_resize(int x, int y, int w, int h) {                                           \
+            Fl_Widget::resize(x, y, w, h);                                                         \
+            redraw();                                                                              \
         }                                                                                          \
         void set_handler(handler h) {                                                              \
             inner_handler = h;                                                                     \
@@ -220,6 +225,9 @@ typedef void (*custom_draw_callback2)(Fl_Widget *, void *);
     }                                                                                              \
     void widget##_resize(widget *self, int x, int y, int width, int height) {                      \
         LOCK(self->resize(x, y, width, height);)                                                   \
+    }                                                                                              \
+    void widget##_widget_resize(widget *self, int x, int y, int width, int height) {               \
+        LOCK(((widget##_Derived *)self)->widget_resize(x, y, width, height))                       \
     }                                                                                              \
     const char *widget##_tooltip(widget *self) {                                                   \
         return self->tooltip();                                                                    \

--- a/fltk-sys/cfltk/include/cfl_widget.h
+++ b/fltk-sys/cfltk/include/cfl_widget.h
@@ -42,6 +42,7 @@ typedef void (*custom_draw_callback2)(Fl_Widget *, void *);
     void widget##_set_type(widget *, int typ);                                                     \
     unsigned int widget##_color(widget *);                                                         \
     void widget##_set_color(widget *, unsigned int color);                                         \
+    void widget##_measure_label(const widget *, int *, int *);                                     \
     unsigned int widget##_label_color(widget *);                                                   \
     void widget##_set_label_color(widget *, unsigned int color);                                   \
     int widget##_label_font(widget *);                                                             \
@@ -246,6 +247,9 @@ typedef void (*custom_draw_callback2)(Fl_Widget *, void *);
     }                                                                                              \
     void widget##_set_color(widget *self, unsigned int color) {                                    \
         LOCK(self->color(color);)                                                                  \
+    }                                                                                              \
+    void widget##_measure_label(const widget *self, int *x, int *y) {                              \
+        self->measure_label(*x, *y);                                                               \
     }                                                                                              \
     unsigned int widget##_label_color(widget *self) {                                              \
         return self->labelcolor();                                                                 \

--- a/fltk-sys/cfltk/src/cfl_table.cpp
+++ b/fltk-sys/cfltk/src/cfl_table.cpp
@@ -30,6 +30,10 @@
         operator table *() {                                                                       \
             return (table *)this;                                                                  \
         }                                                                                          \
+        void widget_resize(int x, int y, int w, int h) {                                           \
+            Fl_Widget::resize(x, y, w, h);                                                         \
+            redraw();                                                                              \
+        }                                                                                          \
         void set_handler(handler h) {                                                              \
             inner_handler = h;                                                                     \
         }                                                                                          \

--- a/fltk-sys/cfltk/src/cfl_widget.cpp
+++ b/fltk-sys/cfltk/src/cfl_widget.cpp
@@ -26,6 +26,11 @@ struct Fl_Widget_Derived : public Fl_Widget {
         return (Fl_Widget *)this;
     }
 
+    void widget_resize(int x, int y, int w, int h) {
+        Fl_Widget::resize(x, y, w, h);
+        redraw();
+    }
+
     void set_handler(handler h) {
         inner_handler = h;
     }

--- a/fltk-sys/src/browser.rs
+++ b/fltk-sys/src/browser.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Browser_set_color(arg1: *mut Fl_Browser, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Browser_measure_label(
+        arg1: *const Fl_Browser,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Browser_label_color(arg1: *mut Fl_Browser) -> libc::c_uint;
@@ -755,6 +769,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Hold_Browser_set_color(arg1: *mut Fl_Hold_Browser, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Hold_Browser_measure_label(
+        arg1: *const Fl_Hold_Browser,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Hold_Browser_label_color(arg1: *mut Fl_Hold_Browser) -> libc::c_uint;
@@ -1168,6 +1189,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Select_Browser_set_color(arg1: *mut Fl_Select_Browser, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Select_Browser_measure_label(
+        arg1: *const Fl_Select_Browser,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Select_Browser_label_color(arg1: *mut Fl_Select_Browser) -> libc::c_uint;
@@ -1595,6 +1623,13 @@ extern "C" {
     pub fn Fl_Multi_Browser_set_color(arg1: *mut Fl_Multi_Browser, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Multi_Browser_measure_label(
+        arg1: *const Fl_Multi_Browser,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Multi_Browser_label_color(arg1: *mut Fl_Multi_Browser) -> libc::c_uint;
 }
 extern "C" {
@@ -2011,6 +2046,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_File_Browser_set_color(arg1: *mut Fl_File_Browser, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_File_Browser_measure_label(
+        arg1: *const Fl_File_Browser,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_File_Browser_label_color(arg1: *mut Fl_File_Browser) -> libc::c_uint;

--- a/fltk-sys/src/browser.rs
+++ b/fltk-sys/src/browser.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Browser_resize(
+        arg1: *mut Fl_Browser,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Browser_widget_resize(
         arg1: *mut Fl_Browser,
         x: libc::c_int,
         y: libc::c_int,
@@ -704,6 +722,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Hold_Browser_resize(
+        arg1: *mut Fl_Hold_Browser,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Hold_Browser_widget_resize(
         arg1: *mut Fl_Hold_Browser,
         x: libc::c_int,
         y: libc::c_int,
@@ -1108,6 +1135,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Select_Browser_resize(
+        arg1: *mut Fl_Select_Browser,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Select_Browser_widget_resize(
         arg1: *mut Fl_Select_Browser,
         x: libc::c_int,
         y: libc::c_int,
@@ -1532,6 +1568,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Multi_Browser_widget_resize(
+        arg1: *mut Fl_Multi_Browser,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Multi_Browser_tooltip(arg1: *mut Fl_Multi_Browser) -> *const libc::c_char;
 }
 extern "C" {
@@ -1933,6 +1978,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_File_Browser_resize(
+        arg1: *mut Fl_File_Browser,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_File_Browser_widget_resize(
         arg1: *mut Fl_File_Browser,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/button.rs
+++ b/fltk-sys/src/button.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Button_set_color(arg1: *mut Fl_Button, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Button_measure_label(
+        arg1: *const Fl_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Button_label_color(arg1: *mut Fl_Button) -> libc::c_uint;
@@ -632,6 +646,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Check_Button_set_color(arg1: *mut Fl_Check_Button, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Check_Button_measure_label(
+        arg1: *const Fl_Check_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Check_Button_label_color(arg1: *mut Fl_Check_Button) -> libc::c_uint;
@@ -920,6 +941,13 @@ extern "C" {
     pub fn Fl_Radio_Button_set_color(arg1: *mut Fl_Radio_Button, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Radio_Button_measure_label(
+        arg1: *const Fl_Radio_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Radio_Button_label_color(arg1: *mut Fl_Radio_Button) -> libc::c_uint;
 }
 extern "C" {
@@ -1206,6 +1234,13 @@ extern "C" {
     pub fn Fl_Toggle_Button_set_color(arg1: *mut Fl_Toggle_Button, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Toggle_Button_measure_label(
+        arg1: *const Fl_Toggle_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Toggle_Button_label_color(arg1: *mut Fl_Toggle_Button) -> libc::c_uint;
 }
 extern "C" {
@@ -1490,6 +1525,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Round_Button_set_color(arg1: *mut Fl_Round_Button, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Round_Button_measure_label(
+        arg1: *const Fl_Round_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Round_Button_label_color(arg1: *mut Fl_Round_Button) -> libc::c_uint;
@@ -1782,6 +1824,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Radio_Round_Button_set_color(arg1: *mut Fl_Radio_Round_Button, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Radio_Round_Button_measure_label(
+        arg1: *const Fl_Radio_Round_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Radio_Round_Button_label_color(arg1: *mut Fl_Radio_Round_Button) -> libc::c_uint;
@@ -2112,6 +2161,13 @@ extern "C" {
     pub fn Fl_Radio_Light_Button_set_color(arg1: *mut Fl_Radio_Light_Button, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Radio_Light_Button_measure_label(
+        arg1: *const Fl_Radio_Light_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Radio_Light_Button_label_color(arg1: *mut Fl_Radio_Light_Button) -> libc::c_uint;
 }
 extern "C" {
@@ -2434,6 +2490,13 @@ extern "C" {
     pub fn Fl_Light_Button_set_color(arg1: *mut Fl_Light_Button, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Light_Button_measure_label(
+        arg1: *const Fl_Light_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Light_Button_label_color(arg1: *mut Fl_Light_Button) -> libc::c_uint;
 }
 extern "C" {
@@ -2720,6 +2783,13 @@ extern "C" {
     pub fn Fl_Repeat_Button_set_color(arg1: *mut Fl_Repeat_Button, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Repeat_Button_measure_label(
+        arg1: *const Fl_Repeat_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Repeat_Button_label_color(arg1: *mut Fl_Repeat_Button) -> libc::c_uint;
 }
 extern "C" {
@@ -2998,6 +3068,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Return_Button_set_color(arg1: *mut Fl_Return_Button, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Return_Button_measure_label(
+        arg1: *const Fl_Return_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Return_Button_label_color(arg1: *mut Fl_Return_Button) -> libc::c_uint;

--- a/fltk-sys/src/button.rs
+++ b/fltk-sys/src/button.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Button_resize(
+        arg1: *mut Fl_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Button_widget_resize(
         arg1: *mut Fl_Button,
         x: libc::c_int,
         y: libc::c_int,
@@ -581,6 +599,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Check_Button_resize(
+        arg1: *mut Fl_Check_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Check_Button_widget_resize(
         arg1: *mut Fl_Check_Button,
         x: libc::c_int,
         y: libc::c_int,
@@ -866,6 +893,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Radio_Button_widget_resize(
+        arg1: *mut Fl_Radio_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Radio_Button_tooltip(arg1: *mut Fl_Radio_Button) -> *const libc::c_char;
 }
 extern "C" {
@@ -1135,6 +1171,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Toggle_Button_resize(
+        arg1: *mut Fl_Toggle_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Toggle_Button_widget_resize(
         arg1: *mut Fl_Toggle_Button,
         x: libc::c_int,
         y: libc::c_int,
@@ -1420,6 +1465,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Round_Button_widget_resize(
+        arg1: *mut Fl_Round_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Round_Button_tooltip(arg1: *mut Fl_Round_Button) -> *const libc::c_char;
 }
 extern "C" {
@@ -1692,6 +1746,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Radio_Round_Button_resize(
+        arg1: *mut Fl_Radio_Round_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Radio_Round_Button_widget_resize(
         arg1: *mut Fl_Radio_Round_Button,
         x: libc::c_int,
         y: libc::c_int,
@@ -2019,6 +2082,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Radio_Light_Button_widget_resize(
+        arg1: *mut Fl_Radio_Light_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Radio_Light_Button_tooltip(arg1: *mut Fl_Radio_Light_Button) -> *const libc::c_char;
 }
 extern "C" {
@@ -2335,6 +2407,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Light_Button_widget_resize(
+        arg1: *mut Fl_Light_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Light_Button_tooltip(arg1: *mut Fl_Light_Button) -> *const libc::c_char;
 }
 extern "C" {
@@ -2612,6 +2693,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Repeat_Button_widget_resize(
+        arg1: *mut Fl_Repeat_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Repeat_Button_tooltip(arg1: *mut Fl_Repeat_Button) -> *const libc::c_char;
 }
 extern "C" {
@@ -2875,6 +2965,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Return_Button_resize(
+        arg1: *mut Fl_Return_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Return_Button_widget_resize(
         arg1: *mut Fl_Return_Button,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/frame.rs
+++ b/fltk-sys/src/frame.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Box_set_color(arg1: *mut Fl_Box, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Box_measure_label(
+        arg1: *const Fl_Box,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Box_label_color(arg1: *mut Fl_Box) -> libc::c_uint;

--- a/fltk-sys/src/frame.rs
+++ b/fltk-sys/src/frame.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Box_resize(
+        arg1: *mut Fl_Box,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Box_widget_resize(
         arg1: *mut Fl_Box,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/group.rs
+++ b/fltk-sys/src/group.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Group_set_color(arg1: *mut Fl_Group, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Group_measure_label(
+        arg1: *const Fl_Group,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Group_label_color(arg1: *mut Fl_Group) -> libc::c_uint;
@@ -649,6 +663,13 @@ extern "C" {
     pub fn Fl_Pack_set_color(arg1: *mut Fl_Pack, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Pack_measure_label(
+        arg1: *const Fl_Pack,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Pack_label_color(arg1: *mut Fl_Pack) -> libc::c_uint;
 }
 extern "C" {
@@ -931,6 +952,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Scroll_set_color(arg1: *mut Fl_Scroll, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Scroll_measure_label(
+        arg1: *const Fl_Scroll,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Scroll_label_color(arg1: *mut Fl_Scroll) -> libc::c_uint;
@@ -1240,6 +1268,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Tabs_set_color(arg1: *mut Fl_Tabs, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Tabs_measure_label(
+        arg1: *const Fl_Tabs,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Tabs_label_color(arg1: *mut Fl_Tabs) -> libc::c_uint;
@@ -1553,6 +1588,13 @@ extern "C" {
     pub fn Fl_Tile_set_color(arg1: *mut Fl_Tile, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Tile_measure_label(
+        arg1: *const Fl_Tile,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Tile_label_color(arg1: *mut Fl_Tile) -> libc::c_uint;
 }
 extern "C" {
@@ -1835,6 +1877,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Wizard_set_color(arg1: *mut Fl_Wizard, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Wizard_measure_label(
+        arg1: *const Fl_Wizard,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Wizard_label_color(arg1: *mut Fl_Wizard) -> libc::c_uint;
@@ -2135,6 +2184,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Color_Chooser_set_color(arg1: *mut Fl_Color_Chooser, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Color_Chooser_measure_label(
+        arg1: *const Fl_Color_Chooser,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Color_Chooser_label_color(arg1: *mut Fl_Color_Chooser) -> libc::c_uint;

--- a/fltk-sys/src/group.rs
+++ b/fltk-sys/src/group.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Group_resize(
+        arg1: *mut Fl_Group,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Group_widget_resize(
         arg1: *mut Fl_Group,
         x: libc::c_int,
         y: libc::c_int,
@@ -604,6 +622,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Pack_widget_resize(
+        arg1: *mut Fl_Pack,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Pack_tooltip(arg1: *mut Fl_Pack) -> *const libc::c_char;
 }
 extern "C" {
@@ -871,6 +898,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Scroll_resize(
+        arg1: *mut Fl_Scroll,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Scroll_widget_resize(
         arg1: *mut Fl_Scroll,
         x: libc::c_int,
         y: libc::c_int,
@@ -1171,6 +1207,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Tabs_resize(
+        arg1: *mut Fl_Tabs,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Tabs_widget_resize(
         arg1: *mut Fl_Tabs,
         x: libc::c_int,
         y: libc::c_int,
@@ -1481,6 +1526,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Tile_widget_resize(
+        arg1: *mut Fl_Tile,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Tile_tooltip(arg1: *mut Fl_Tile) -> *const libc::c_char;
 }
 extern "C" {
@@ -1748,6 +1802,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Wizard_resize(
+        arg1: *mut Fl_Wizard,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Wizard_widget_resize(
         arg1: *mut Fl_Wizard,
         x: libc::c_int,
         y: libc::c_int,
@@ -2039,6 +2102,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Color_Chooser_resize(
+        arg1: *mut Fl_Color_Chooser,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Color_Chooser_widget_resize(
         arg1: *mut Fl_Color_Chooser,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/input.rs
+++ b/fltk-sys/src/input.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Input_resize(
+        arg1: *mut Fl_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Input_widget_resize(
         arg1: *mut Fl_Input,
         x: libc::c_int,
         y: libc::c_int,
@@ -653,6 +671,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Int_Input_resize(
+        arg1: *mut Fl_Int_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Int_Input_widget_resize(
         arg1: *mut Fl_Int_Input,
         x: libc::c_int,
         y: libc::c_int,
@@ -1004,6 +1031,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Float_Input_widget_resize(
+        arg1: *mut Fl_Float_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Float_Input_tooltip(arg1: *mut Fl_Float_Input) -> *const libc::c_char;
 }
 extern "C" {
@@ -1342,6 +1378,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Multiline_Input_resize(
+        arg1: *mut Fl_Multiline_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Multiline_Input_widget_resize(
         arg1: *mut Fl_Multiline_Input,
         x: libc::c_int,
         y: libc::c_int,
@@ -1714,6 +1759,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Secret_Input_widget_resize(
+        arg1: *mut Fl_Secret_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Secret_Input_tooltip(arg1: *mut Fl_Secret_Input) -> *const libc::c_char;
 }
 extern "C" {
@@ -2052,6 +2106,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_File_Input_resize(
+        arg1: *mut Fl_File_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_File_Input_widget_resize(
         arg1: *mut Fl_File_Input,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/input.rs
+++ b/fltk-sys/src/input.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Input_set_color(arg1: *mut Fl_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Input_measure_label(
+        arg1: *const Fl_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Input_label_color(arg1: *mut Fl_Input) -> libc::c_uint;
@@ -704,6 +718,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Int_Input_set_color(arg1: *mut Fl_Int_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Int_Input_measure_label(
+        arg1: *const Fl_Int_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Int_Input_label_color(arg1: *mut Fl_Int_Input) -> libc::c_uint;
@@ -1056,6 +1077,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Float_Input_set_color(arg1: *mut Fl_Float_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Float_Input_measure_label(
+        arg1: *const Fl_Float_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Float_Input_label_color(arg1: *mut Fl_Float_Input) -> libc::c_uint;
@@ -1411,6 +1439,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Multiline_Input_set_color(arg1: *mut Fl_Multiline_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Multiline_Input_measure_label(
+        arg1: *const Fl_Multiline_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Multiline_Input_label_color(arg1: *mut Fl_Multiline_Input) -> libc::c_uint;
@@ -1786,6 +1821,13 @@ extern "C" {
     pub fn Fl_Secret_Input_set_color(arg1: *mut Fl_Secret_Input, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Secret_Input_measure_label(
+        arg1: *const Fl_Secret_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Secret_Input_label_color(arg1: *mut Fl_Secret_Input) -> libc::c_uint;
 }
 extern "C" {
@@ -2139,6 +2181,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_File_Input_set_color(arg1: *mut Fl_File_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_File_Input_measure_label(
+        arg1: *const Fl_File_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_File_Input_label_color(arg1: *mut Fl_File_Input) -> libc::c_uint;

--- a/fltk-sys/src/menu.rs
+++ b/fltk-sys/src/menu.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -322,6 +331,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Menu_Bar_resize(
+        arg1: *mut Fl_Menu_Bar,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Menu_Bar_widget_resize(
         arg1: *mut Fl_Menu_Bar,
         x: libc::c_int,
         y: libc::c_int,
@@ -668,6 +686,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Menu_Button_resize(
+        arg1: *mut Fl_Menu_Button,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Menu_Button_widget_resize(
         arg1: *mut Fl_Menu_Button,
         x: libc::c_int,
         y: libc::c_int,
@@ -1034,6 +1061,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Choice_widget_resize(
+        arg1: *mut Fl_Choice,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Choice_tooltip(arg1: *mut Fl_Choice) -> *const libc::c_char;
 }
 extern "C" {
@@ -1364,6 +1400,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Sys_Menu_Bar_resize(
+        arg1: *mut Fl_Sys_Menu_Bar,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Sys_Menu_Bar_widget_resize(
         arg1: *mut Fl_Sys_Menu_Bar,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/menu.rs
+++ b/fltk-sys/src/menu.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -364,6 +371,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Menu_Bar_set_color(arg1: *mut Fl_Menu_Bar, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Menu_Bar_measure_label(
+        arg1: *const Fl_Menu_Bar,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Menu_Bar_label_color(arg1: *mut Fl_Menu_Bar) -> libc::c_uint;
@@ -719,6 +733,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Menu_Button_set_color(arg1: *mut Fl_Menu_Button, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Menu_Button_measure_label(
+        arg1: *const Fl_Menu_Button,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Menu_Button_label_color(arg1: *mut Fl_Menu_Button) -> libc::c_uint;
@@ -1088,6 +1109,13 @@ extern "C" {
     pub fn Fl_Choice_set_color(arg1: *mut Fl_Choice, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Choice_measure_label(
+        arg1: *const Fl_Choice,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Choice_label_color(arg1: *mut Fl_Choice) -> libc::c_uint;
 }
 extern "C" {
@@ -1433,6 +1461,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Sys_Menu_Bar_set_color(arg1: *mut Fl_Sys_Menu_Bar, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Sys_Menu_Bar_measure_label(
+        arg1: *const Fl_Sys_Menu_Bar,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Sys_Menu_Bar_label_color(arg1: *mut Fl_Sys_Menu_Bar) -> libc::c_uint;

--- a/fltk-sys/src/misc.rs
+++ b/fltk-sys/src/misc.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Spinner_resize(
+        arg1: *mut Fl_Spinner,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Spinner_widget_resize(
         arg1: *mut Fl_Spinner,
         x: libc::c_int,
         y: libc::c_int,
@@ -623,6 +641,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Clock_widget_resize(
+        arg1: *mut Fl_Clock,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Clock_tooltip(arg1: *mut Fl_Clock) -> *const libc::c_char;
 }
 extern "C" {
@@ -864,6 +891,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Chart_resize(
+        arg1: *mut Fl_Chart,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Chart_widget_resize(
         arg1: *mut Fl_Chart,
         x: libc::c_int,
         y: libc::c_int,
@@ -1181,6 +1217,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Progress_resize(
+        arg1: *mut Fl_Progress,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Progress_widget_resize(
         arg1: *mut Fl_Progress,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/misc.rs
+++ b/fltk-sys/src/misc.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Spinner_set_color(arg1: *mut Fl_Spinner, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Spinner_measure_label(
+        arg1: *const Fl_Spinner,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Spinner_label_color(arg1: *mut Fl_Spinner) -> libc::c_uint;
@@ -668,6 +682,13 @@ extern "C" {
     pub fn Fl_Clock_set_color(arg1: *mut Fl_Clock, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Clock_measure_label(
+        arg1: *const Fl_Clock,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Clock_label_color(arg1: *mut Fl_Clock) -> libc::c_uint;
 }
 extern "C" {
@@ -924,6 +945,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Chart_set_color(arg1: *mut Fl_Chart, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Chart_measure_label(
+        arg1: *const Fl_Chart,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Chart_label_color(arg1: *mut Fl_Chart) -> libc::c_uint;
@@ -1250,6 +1278,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Progress_set_color(arg1: *mut Fl_Progress, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Progress_measure_label(
+        arg1: *const Fl_Progress,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Progress_label_color(arg1: *mut Fl_Progress) -> libc::c_uint;

--- a/fltk-sys/src/output.rs
+++ b/fltk-sys/src/output.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Input_resize(
+        arg1: *mut Fl_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Input_widget_resize(
         arg1: *mut Fl_Input,
         x: libc::c_int,
         y: libc::c_int,
@@ -653,6 +671,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Int_Input_resize(
+        arg1: *mut Fl_Int_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Int_Input_widget_resize(
         arg1: *mut Fl_Int_Input,
         x: libc::c_int,
         y: libc::c_int,
@@ -1004,6 +1031,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Float_Input_widget_resize(
+        arg1: *mut Fl_Float_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Float_Input_tooltip(arg1: *mut Fl_Float_Input) -> *const libc::c_char;
 }
 extern "C" {
@@ -1342,6 +1378,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Multiline_Input_resize(
+        arg1: *mut Fl_Multiline_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Multiline_Input_widget_resize(
         arg1: *mut Fl_Multiline_Input,
         x: libc::c_int,
         y: libc::c_int,
@@ -1714,6 +1759,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Secret_Input_widget_resize(
+        arg1: *mut Fl_Secret_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Secret_Input_tooltip(arg1: *mut Fl_Secret_Input) -> *const libc::c_char;
 }
 extern "C" {
@@ -2052,6 +2106,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_File_Input_resize(
+        arg1: *mut Fl_File_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_File_Input_widget_resize(
         arg1: *mut Fl_File_Input,
         x: libc::c_int,
         y: libc::c_int,
@@ -2406,6 +2469,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Output_widget_resize(
+        arg1: *mut Fl_Output,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Output_tooltip(arg1: *mut Fl_Output) -> *const libc::c_char;
 }
 extern "C" {
@@ -2737,6 +2809,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Multiline_Output_resize(
+        arg1: *mut Fl_Multiline_Output,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Multiline_Output_widget_resize(
         arg1: *mut Fl_Multiline_Output,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/output.rs
+++ b/fltk-sys/src/output.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Input_set_color(arg1: *mut Fl_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Input_measure_label(
+        arg1: *const Fl_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Input_label_color(arg1: *mut Fl_Input) -> libc::c_uint;
@@ -704,6 +718,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Int_Input_set_color(arg1: *mut Fl_Int_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Int_Input_measure_label(
+        arg1: *const Fl_Int_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Int_Input_label_color(arg1: *mut Fl_Int_Input) -> libc::c_uint;
@@ -1056,6 +1077,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Float_Input_set_color(arg1: *mut Fl_Float_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Float_Input_measure_label(
+        arg1: *const Fl_Float_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Float_Input_label_color(arg1: *mut Fl_Float_Input) -> libc::c_uint;
@@ -1411,6 +1439,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Multiline_Input_set_color(arg1: *mut Fl_Multiline_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Multiline_Input_measure_label(
+        arg1: *const Fl_Multiline_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Multiline_Input_label_color(arg1: *mut Fl_Multiline_Input) -> libc::c_uint;
@@ -1786,6 +1821,13 @@ extern "C" {
     pub fn Fl_Secret_Input_set_color(arg1: *mut Fl_Secret_Input, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Secret_Input_measure_label(
+        arg1: *const Fl_Secret_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Secret_Input_label_color(arg1: *mut Fl_Secret_Input) -> libc::c_uint;
 }
 extern "C" {
@@ -2139,6 +2181,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_File_Input_set_color(arg1: *mut Fl_File_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_File_Input_measure_label(
+        arg1: *const Fl_File_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_File_Input_label_color(arg1: *mut Fl_File_Input) -> libc::c_uint;
@@ -2496,6 +2545,13 @@ extern "C" {
     pub fn Fl_Output_set_color(arg1: *mut Fl_Output, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Output_measure_label(
+        arg1: *const Fl_Output,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Output_label_color(arg1: *mut Fl_Output) -> libc::c_uint;
 }
 extern "C" {
@@ -2845,6 +2901,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Multiline_Output_set_color(arg1: *mut Fl_Multiline_Output, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Multiline_Output_measure_label(
+        arg1: *const Fl_Multiline_Output,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Multiline_Output_label_color(arg1: *mut Fl_Multiline_Output) -> libc::c_uint;

--- a/fltk-sys/src/table.rs
+++ b/fltk-sys/src/table.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Group_set_color(arg1: *mut Fl_Group, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Group_measure_label(
+        arg1: *const Fl_Group,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Group_label_color(arg1: *mut Fl_Group) -> libc::c_uint;
@@ -649,6 +663,13 @@ extern "C" {
     pub fn Fl_Pack_set_color(arg1: *mut Fl_Pack, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Pack_measure_label(
+        arg1: *const Fl_Pack,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Pack_label_color(arg1: *mut Fl_Pack) -> libc::c_uint;
 }
 extern "C" {
@@ -931,6 +952,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Scroll_set_color(arg1: *mut Fl_Scroll, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Scroll_measure_label(
+        arg1: *const Fl_Scroll,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Scroll_label_color(arg1: *mut Fl_Scroll) -> libc::c_uint;
@@ -1240,6 +1268,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Tabs_set_color(arg1: *mut Fl_Tabs, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Tabs_measure_label(
+        arg1: *const Fl_Tabs,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Tabs_label_color(arg1: *mut Fl_Tabs) -> libc::c_uint;
@@ -1553,6 +1588,13 @@ extern "C" {
     pub fn Fl_Tile_set_color(arg1: *mut Fl_Tile, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Tile_measure_label(
+        arg1: *const Fl_Tile,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Tile_label_color(arg1: *mut Fl_Tile) -> libc::c_uint;
 }
 extern "C" {
@@ -1835,6 +1877,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Wizard_set_color(arg1: *mut Fl_Wizard, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Wizard_measure_label(
+        arg1: *const Fl_Wizard,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Wizard_label_color(arg1: *mut Fl_Wizard) -> libc::c_uint;
@@ -2135,6 +2184,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Color_Chooser_set_color(arg1: *mut Fl_Color_Chooser, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Color_Chooser_measure_label(
+        arg1: *const Fl_Color_Chooser,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Color_Chooser_label_color(arg1: *mut Fl_Color_Chooser) -> libc::c_uint;
@@ -2455,6 +2511,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Table_set_color(arg1: *mut Fl_Table, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Table_measure_label(
+        arg1: *const Fl_Table,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Table_label_color(arg1: *mut Fl_Table) -> libc::c_uint;
@@ -2967,6 +3030,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Table_Row_set_color(arg1: *mut Fl_Table_Row, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Table_Row_measure_label(
+        arg1: *const Fl_Table_Row,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Table_Row_label_color(arg1: *mut Fl_Table_Row) -> libc::c_uint;

--- a/fltk-sys/src/table.rs
+++ b/fltk-sys/src/table.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Group_resize(
+        arg1: *mut Fl_Group,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Group_widget_resize(
         arg1: *mut Fl_Group,
         x: libc::c_int,
         y: libc::c_int,
@@ -604,6 +622,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Pack_widget_resize(
+        arg1: *mut Fl_Pack,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Pack_tooltip(arg1: *mut Fl_Pack) -> *const libc::c_char;
 }
 extern "C" {
@@ -871,6 +898,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Scroll_resize(
+        arg1: *mut Fl_Scroll,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Scroll_widget_resize(
         arg1: *mut Fl_Scroll,
         x: libc::c_int,
         y: libc::c_int,
@@ -1171,6 +1207,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Tabs_resize(
+        arg1: *mut Fl_Tabs,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Tabs_widget_resize(
         arg1: *mut Fl_Tabs,
         x: libc::c_int,
         y: libc::c_int,
@@ -1481,6 +1526,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Tile_widget_resize(
+        arg1: *mut Fl_Tile,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Tile_tooltip(arg1: *mut Fl_Tile) -> *const libc::c_char;
 }
 extern "C" {
@@ -1748,6 +1802,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Wizard_resize(
+        arg1: *mut Fl_Wizard,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Wizard_widget_resize(
         arg1: *mut Fl_Wizard,
         x: libc::c_int,
         y: libc::c_int,
@@ -2039,6 +2102,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Color_Chooser_resize(
+        arg1: *mut Fl_Color_Chooser,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Color_Chooser_widget_resize(
         arg1: *mut Fl_Color_Chooser,
         x: libc::c_int,
         y: libc::c_int,
@@ -2350,6 +2422,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Table_resize(
+        arg1: *mut Fl_Table,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Table_widget_resize(
         arg1: *mut Fl_Table,
         x: libc::c_int,
         y: libc::c_int,
@@ -2853,6 +2934,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Table_Row_resize(
+        arg1: *mut Fl_Table_Row,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Table_Row_widget_resize(
         arg1: *mut Fl_Table_Row,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/text.rs
+++ b/fltk-sys/src/text.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -497,6 +506,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Text_Display_resize(
+        arg1: *mut Fl_Text_Display,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Text_Display_widget_resize(
         arg1: *mut Fl_Text_Display,
         x: libc::c_int,
         y: libc::c_int,
@@ -983,6 +1001,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Text_Editor_resize(
+        arg1: *mut Fl_Text_Editor,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Text_Editor_widget_resize(
         arg1: *mut Fl_Text_Editor,
         x: libc::c_int,
         y: libc::c_int,
@@ -1551,6 +1578,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Simple_Terminal_resize(
+        arg1: *mut Fl_Simple_Terminal,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Simple_Terminal_widget_resize(
         arg1: *mut Fl_Simple_Terminal,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/text.rs
+++ b/fltk-sys/src/text.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -539,6 +546,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Text_Display_set_color(arg1: *mut Fl_Text_Display, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Text_Display_measure_label(
+        arg1: *const Fl_Text_Display,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Text_Display_label_color(arg1: *mut Fl_Text_Display) -> libc::c_uint;
@@ -1034,6 +1048,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Text_Editor_set_color(arg1: *mut Fl_Text_Editor, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Text_Editor_measure_label(
+        arg1: *const Fl_Text_Editor,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Text_Editor_label_color(arg1: *mut Fl_Text_Editor) -> libc::c_uint;
@@ -1611,6 +1632,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Simple_Terminal_set_color(arg1: *mut Fl_Simple_Terminal, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Simple_Terminal_measure_label(
+        arg1: *const Fl_Simple_Terminal,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Simple_Terminal_label_color(arg1: *mut Fl_Simple_Terminal) -> libc::c_uint;

--- a/fltk-sys/src/tree.rs
+++ b/fltk-sys/src/tree.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Tree_set_color(arg1: *mut Fl_Tree, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Tree_measure_label(
+        arg1: *const Fl_Tree,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Tree_label_color(arg1: *mut Fl_Tree) -> libc::c_uint;

--- a/fltk-sys/src/tree.rs
+++ b/fltk-sys/src/tree.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Tree_resize(
+        arg1: *mut Fl_Tree,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Tree_widget_resize(
         arg1: *mut Fl_Tree,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/valuator.rs
+++ b/fltk-sys/src/valuator.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Slider_set_color(arg1: *mut Fl_Slider, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Slider_measure_label(
+        arg1: *const Fl_Slider,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Slider_label_color(arg1: *mut Fl_Slider) -> libc::c_uint;
@@ -662,6 +676,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Nice_Slider_set_color(arg1: *mut Fl_Nice_Slider, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Nice_Slider_measure_label(
+        arg1: *const Fl_Nice_Slider,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Nice_Slider_label_color(arg1: *mut Fl_Nice_Slider) -> libc::c_uint;
@@ -976,6 +997,13 @@ extern "C" {
     pub fn Fl_Counter_set_color(arg1: *mut Fl_Counter, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Counter_measure_label(
+        arg1: *const Fl_Counter,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Counter_label_color(arg1: *mut Fl_Counter) -> libc::c_uint;
 }
 extern "C" {
@@ -1283,6 +1311,13 @@ extern "C" {
     pub fn Fl_Dial_set_color(arg1: *mut Fl_Dial, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Dial_measure_label(
+        arg1: *const Fl_Dial,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Dial_label_color(arg1: *mut Fl_Dial) -> libc::c_uint;
 }
 extern "C" {
@@ -1580,6 +1615,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Line_Dial_set_color(arg1: *mut Fl_Line_Dial, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Line_Dial_measure_label(
+        arg1: *const Fl_Line_Dial,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Line_Dial_label_color(arg1: *mut Fl_Line_Dial) -> libc::c_uint;
@@ -1889,6 +1931,13 @@ extern "C" {
     pub fn Fl_Roller_set_color(arg1: *mut Fl_Roller, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Roller_measure_label(
+        arg1: *const Fl_Roller,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Roller_label_color(arg1: *mut Fl_Roller) -> libc::c_uint;
 }
 extern "C" {
@@ -2190,6 +2239,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Scrollbar_set_color(arg1: *mut Fl_Scrollbar, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Scrollbar_measure_label(
+        arg1: *const Fl_Scrollbar,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Scrollbar_label_color(arg1: *mut Fl_Scrollbar) -> libc::c_uint;
@@ -2497,6 +2553,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Value_Slider_set_color(arg1: *mut Fl_Value_Slider, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Value_Slider_measure_label(
+        arg1: *const Fl_Value_Slider,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Value_Slider_label_color(arg1: *mut Fl_Value_Slider) -> libc::c_uint;
@@ -2816,6 +2879,13 @@ extern "C" {
     pub fn Fl_Adjuster_set_color(arg1: *mut Fl_Adjuster, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Adjuster_measure_label(
+        arg1: *const Fl_Adjuster,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Adjuster_label_color(arg1: *mut Fl_Adjuster) -> libc::c_uint;
 }
 extern "C" {
@@ -3121,6 +3191,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Value_Input_set_color(arg1: *mut Fl_Value_Input, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Value_Input_measure_label(
+        arg1: *const Fl_Value_Input,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Value_Input_label_color(arg1: *mut Fl_Value_Input) -> libc::c_uint;
@@ -3433,6 +3510,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Value_Output_set_color(arg1: *mut Fl_Value_Output, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Value_Output_measure_label(
+        arg1: *const Fl_Value_Output,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Value_Output_label_color(arg1: *mut Fl_Value_Output) -> libc::c_uint;
@@ -3752,6 +3836,13 @@ extern "C" {
     pub fn Fl_Fill_Slider_set_color(arg1: *mut Fl_Fill_Slider, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Fill_Slider_measure_label(
+        arg1: *const Fl_Fill_Slider,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Fill_Slider_label_color(arg1: *mut Fl_Fill_Slider) -> libc::c_uint;
 }
 extern "C" {
@@ -4064,6 +4155,13 @@ extern "C" {
     pub fn Fl_Fill_Dial_set_color(arg1: *mut Fl_Fill_Dial, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Fill_Dial_measure_label(
+        arg1: *const Fl_Fill_Dial,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Fill_Dial_label_color(arg1: *mut Fl_Fill_Dial) -> libc::c_uint;
 }
 extern "C" {
@@ -4369,6 +4467,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Hor_Slider_set_color(arg1: *mut Fl_Hor_Slider, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Hor_Slider_measure_label(
+        arg1: *const Fl_Hor_Slider,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Hor_Slider_label_color(arg1: *mut Fl_Hor_Slider) -> libc::c_uint;
@@ -4679,6 +4784,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Hor_Fill_Slider_set_color(arg1: *mut Fl_Hor_Fill_Slider, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Hor_Fill_Slider_measure_label(
+        arg1: *const Fl_Hor_Fill_Slider,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Hor_Fill_Slider_label_color(arg1: *mut Fl_Hor_Fill_Slider) -> libc::c_uint;
@@ -5005,6 +5117,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Hor_Nice_Slider_set_color(arg1: *mut Fl_Hor_Nice_Slider, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Hor_Nice_Slider_measure_label(
+        arg1: *const Fl_Hor_Nice_Slider,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Hor_Nice_Slider_label_color(arg1: *mut Fl_Hor_Nice_Slider) -> libc::c_uint;
@@ -5337,6 +5456,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Hor_Value_Slider_set_color(arg1: *mut Fl_Hor_Value_Slider, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Hor_Value_Slider_measure_label(
+        arg1: *const Fl_Hor_Value_Slider,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Hor_Value_Slider_label_color(arg1: *mut Fl_Hor_Value_Slider) -> libc::c_uint;

--- a/fltk-sys/src/valuator.rs
+++ b/fltk-sys/src/valuator.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Slider_resize(
+        arg1: *mut Fl_Slider,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Slider_widget_resize(
         arg1: *mut Fl_Slider,
         x: libc::c_int,
         y: libc::c_int,
@@ -611,6 +629,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Nice_Slider_resize(
+        arg1: *mut Fl_Nice_Slider,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Nice_Slider_widget_resize(
         arg1: *mut Fl_Nice_Slider,
         x: libc::c_int,
         y: libc::c_int,
@@ -922,6 +949,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Counter_widget_resize(
+        arg1: *mut Fl_Counter,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Counter_tooltip(arg1: *mut Fl_Counter) -> *const libc::c_char;
 }
 extern "C" {
@@ -1220,6 +1256,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Dial_widget_resize(
+        arg1: *mut Fl_Dial,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Dial_tooltip(arg1: *mut Fl_Dial) -> *const libc::c_char;
 }
 extern "C" {
@@ -1502,6 +1547,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Line_Dial_resize(
+        arg1: *mut Fl_Line_Dial,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Line_Dial_widget_resize(
         arg1: *mut Fl_Line_Dial,
         x: libc::c_int,
         y: libc::c_int,
@@ -1808,6 +1862,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Roller_widget_resize(
+        arg1: *mut Fl_Roller,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Roller_tooltip(arg1: *mut Fl_Roller) -> *const libc::c_char;
 }
 extern "C" {
@@ -2094,6 +2157,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Scrollbar_resize(
+        arg1: *mut Fl_Scrollbar,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Scrollbar_widget_resize(
         arg1: *mut Fl_Scrollbar,
         x: libc::c_int,
         y: libc::c_int,
@@ -2392,6 +2464,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Value_Slider_resize(
+        arg1: *mut Fl_Value_Slider,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Value_Slider_widget_resize(
         arg1: *mut Fl_Value_Slider,
         x: libc::c_int,
         y: libc::c_int,
@@ -2708,6 +2789,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Adjuster_widget_resize(
+        arg1: *mut Fl_Adjuster,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Adjuster_tooltip(arg1: *mut Fl_Adjuster) -> *const libc::c_char;
 }
 extern "C" {
@@ -2998,6 +3088,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Value_Input_resize(
+        arg1: *mut Fl_Value_Input,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Value_Input_widget_resize(
         arg1: *mut Fl_Value_Input,
         x: libc::c_int,
         y: libc::c_int,
@@ -3301,6 +3400,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Value_Output_resize(
+        arg1: *mut Fl_Value_Output,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Value_Output_widget_resize(
         arg1: *mut Fl_Value_Output,
         x: libc::c_int,
         y: libc::c_int,
@@ -3617,6 +3725,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Fill_Slider_widget_resize(
+        arg1: *mut Fl_Fill_Slider,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Fill_Slider_tooltip(arg1: *mut Fl_Fill_Slider) -> *const libc::c_char;
 }
 extern "C" {
@@ -3912,6 +4029,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Fill_Dial_resize(
+        arg1: *mut Fl_Fill_Dial,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Fill_Dial_widget_resize(
         arg1: *mut Fl_Fill_Dial,
         x: libc::c_int,
         y: libc::c_int,
@@ -4218,6 +4344,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Hor_Slider_widget_resize(
+        arg1: *mut Fl_Hor_Slider,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Hor_Slider_tooltip(arg1: *mut Fl_Hor_Slider) -> *const libc::c_char;
 }
 extern "C" {
@@ -4511,6 +4646,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Hor_Fill_Slider_resize(
+        arg1: *mut Fl_Hor_Fill_Slider,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Hor_Fill_Slider_widget_resize(
         arg1: *mut Fl_Hor_Fill_Slider,
         x: libc::c_int,
         y: libc::c_int,
@@ -4836,6 +4980,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Hor_Nice_Slider_widget_resize(
+        arg1: *mut Fl_Hor_Nice_Slider,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Hor_Nice_Slider_tooltip(arg1: *mut Fl_Hor_Nice_Slider) -> *const libc::c_char;
 }
 extern "C" {
@@ -5148,6 +5301,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Hor_Value_Slider_resize(
+        arg1: *mut Fl_Hor_Value_Slider,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Hor_Value_Slider_widget_resize(
         arg1: *mut Fl_Hor_Value_Slider,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk-sys/src/widget.rs
+++ b/fltk-sys/src/widget.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {

--- a/fltk-sys/src/widget.rs
+++ b/fltk-sys/src/widget.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {

--- a/fltk-sys/src/window.rs
+++ b/fltk-sys/src/window.rs
@@ -103,6 +103,13 @@ extern "C" {
     pub fn Fl_Widget_set_color(arg1: *mut Fl_Widget, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Widget_measure_label(
+        arg1: *const Fl_Widget,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_label_color(arg1: *mut Fl_Widget) -> libc::c_uint;
 }
 extern "C" {
@@ -359,6 +366,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Group_set_color(arg1: *mut Fl_Group, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Group_measure_label(
+        arg1: *const Fl_Group,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Group_label_color(arg1: *mut Fl_Group) -> libc::c_uint;
@@ -649,6 +663,13 @@ extern "C" {
     pub fn Fl_Pack_set_color(arg1: *mut Fl_Pack, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Pack_measure_label(
+        arg1: *const Fl_Pack,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Pack_label_color(arg1: *mut Fl_Pack) -> libc::c_uint;
 }
 extern "C" {
@@ -931,6 +952,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Scroll_set_color(arg1: *mut Fl_Scroll, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Scroll_measure_label(
+        arg1: *const Fl_Scroll,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Scroll_label_color(arg1: *mut Fl_Scroll) -> libc::c_uint;
@@ -1240,6 +1268,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Tabs_set_color(arg1: *mut Fl_Tabs, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Tabs_measure_label(
+        arg1: *const Fl_Tabs,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Tabs_label_color(arg1: *mut Fl_Tabs) -> libc::c_uint;
@@ -1553,6 +1588,13 @@ extern "C" {
     pub fn Fl_Tile_set_color(arg1: *mut Fl_Tile, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Tile_measure_label(
+        arg1: *const Fl_Tile,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Tile_label_color(arg1: *mut Fl_Tile) -> libc::c_uint;
 }
 extern "C" {
@@ -1835,6 +1877,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Wizard_set_color(arg1: *mut Fl_Wizard, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Wizard_measure_label(
+        arg1: *const Fl_Wizard,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Wizard_label_color(arg1: *mut Fl_Wizard) -> libc::c_uint;
@@ -2135,6 +2184,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Color_Chooser_set_color(arg1: *mut Fl_Color_Chooser, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Color_Chooser_measure_label(
+        arg1: *const Fl_Color_Chooser,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Color_Chooser_label_color(arg1: *mut Fl_Color_Chooser) -> libc::c_uint;
@@ -2497,6 +2553,13 @@ extern "C" {
     pub fn Fl_Window_set_color(arg1: *mut Fl_Window, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Window_measure_label(
+        arg1: *const Fl_Window,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Window_label_color(arg1: *mut Fl_Window) -> libc::c_uint;
 }
 extern "C" {
@@ -2852,6 +2915,13 @@ extern "C" {
     pub fn Fl_Single_Window_set_color(arg1: *mut Fl_Single_Window, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Single_Window_measure_label(
+        arg1: *const Fl_Single_Window,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Single_Window_label_color(arg1: *mut Fl_Single_Window) -> libc::c_uint;
 }
 extern "C" {
@@ -3200,6 +3270,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Double_Window_set_color(arg1: *mut Fl_Double_Window, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Double_Window_measure_label(
+        arg1: *const Fl_Double_Window,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Double_Window_label_color(arg1: *mut Fl_Double_Window) -> libc::c_uint;
@@ -3555,6 +3632,13 @@ extern "C" {
     pub fn Fl_Menu_Window_set_color(arg1: *mut Fl_Menu_Window, color: libc::c_uint);
 }
 extern "C" {
+    pub fn Fl_Menu_Window_measure_label(
+        arg1: *const Fl_Menu_Window,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Menu_Window_label_color(arg1: *mut Fl_Menu_Window) -> libc::c_uint;
 }
 extern "C" {
@@ -3900,6 +3984,13 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Gl_Window_set_color(arg1: *mut Fl_Gl_Window, color: libc::c_uint);
+}
+extern "C" {
+    pub fn Fl_Gl_Window_measure_label(
+        arg1: *const Fl_Gl_Window,
+        arg2: *mut libc::c_int,
+        arg3: *mut libc::c_int,
+    );
 }
 extern "C" {
     pub fn Fl_Gl_Window_label_color(arg1: *mut Fl_Gl_Window) -> libc::c_uint;

--- a/fltk-sys/src/window.rs
+++ b/fltk-sys/src/window.rs
@@ -76,6 +76,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Widget_widget_resize(
+        arg1: *mut Fl_Widget,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Widget_tooltip(arg1: *mut Fl_Widget) -> *const libc::c_char;
 }
 extern "C" {
@@ -317,6 +326,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Group_resize(
+        arg1: *mut Fl_Group,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Group_widget_resize(
         arg1: *mut Fl_Group,
         x: libc::c_int,
         y: libc::c_int,
@@ -604,6 +622,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Pack_widget_resize(
+        arg1: *mut Fl_Pack,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Pack_tooltip(arg1: *mut Fl_Pack) -> *const libc::c_char;
 }
 extern "C" {
@@ -871,6 +898,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Scroll_resize(
+        arg1: *mut Fl_Scroll,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Scroll_widget_resize(
         arg1: *mut Fl_Scroll,
         x: libc::c_int,
         y: libc::c_int,
@@ -1171,6 +1207,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Tabs_resize(
+        arg1: *mut Fl_Tabs,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Tabs_widget_resize(
         arg1: *mut Fl_Tabs,
         x: libc::c_int,
         y: libc::c_int,
@@ -1481,6 +1526,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Tile_widget_resize(
+        arg1: *mut Fl_Tile,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Tile_tooltip(arg1: *mut Fl_Tile) -> *const libc::c_char;
 }
 extern "C" {
@@ -1748,6 +1802,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Wizard_resize(
+        arg1: *mut Fl_Wizard,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Wizard_widget_resize(
         arg1: *mut Fl_Wizard,
         x: libc::c_int,
         y: libc::c_int,
@@ -2039,6 +2102,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Color_Chooser_resize(
+        arg1: *mut Fl_Color_Chooser,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Color_Chooser_widget_resize(
         arg1: *mut Fl_Color_Chooser,
         x: libc::c_int,
         y: libc::c_int,
@@ -2398,6 +2470,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Window_widget_resize(
+        arg1: *mut Fl_Window,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Window_tooltip(arg1: *mut Fl_Window) -> *const libc::c_char;
 }
 extern "C" {
@@ -2744,6 +2825,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Single_Window_widget_resize(
+        arg1: *mut Fl_Single_Window,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Single_Window_tooltip(arg1: *mut Fl_Single_Window) -> *const libc::c_char;
 }
 extern "C" {
@@ -3077,6 +3167,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Double_Window_resize(
+        arg1: *mut Fl_Double_Window,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Double_Window_widget_resize(
         arg1: *mut Fl_Double_Window,
         x: libc::c_int,
         y: libc::c_int,
@@ -3429,6 +3528,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn Fl_Menu_Window_widget_resize(
+        arg1: *mut Fl_Menu_Window,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
     pub fn Fl_Menu_Window_tooltip(arg1: *mut Fl_Menu_Window) -> *const libc::c_char;
 }
 extern "C" {
@@ -3759,6 +3867,15 @@ extern "C" {
 }
 extern "C" {
     pub fn Fl_Gl_Window_resize(
+        arg1: *mut Fl_Gl_Window,
+        x: libc::c_int,
+        y: libc::c_int,
+        width: libc::c_int,
+        height: libc::c_int,
+    );
+}
+extern "C" {
+    pub fn Fl_Gl_Window_widget_resize(
         arg1: *mut Fl_Gl_Window,
         x: libc::c_int,
         y: libc::c_int,

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.10.4"
+version = "0.10.5"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "^0.10.4" }
-fltk-derive = { path = "../fltk-derive", version = "^0.10.4" }
+fltk-sys = { path = "../fltk-sys", version = "^0.10.5" }
+fltk-derive = { path = "../fltk-derive", version = "^0.10.5" }
 
 [features]
 default = []

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "^0.10.3" }
-fltk-derive = { path = "../fltk-derive", version = "^0.10.3" }
+fltk-sys = { path = "../fltk-sys", version = "^0.10.4" }
+fltk-derive = { path = "../fltk-derive", version = "^0.10.4" }
 
 [features]
 default = []

--- a/fltk/examples/editor.rs
+++ b/fltk/examples/editor.rs
@@ -338,13 +338,13 @@ fn main() {
                     let mut printer = printer::Printer::default();
                     if printer.begin_job(0).is_ok() {
                         let (w, h) = printer.printable_rect();
-                        printable.set_size(w, h);
+                        printable.set_size(w - 40, h - 40);
                         // Needs cleanup
                         let line_count = printable.count_lines(0, printable.buffer().unwrap().length(), true) / 45;
-                        for i in 0..line_count {
+                        for i in 0..=line_count {
                             printable.scroll(45 * i, 0);
                             printer.begin_page();
-                            printer.print_widget(&printable, 0, 0);
+                            printer.print_widget(&printable, 20, 20);
                             printer.end_page();
                         }
                         printer.end_job();

--- a/fltk/examples/editor.rs
+++ b/fltk/examples/editor.rs
@@ -15,7 +15,6 @@ pub fn dlg_y() -> i32 {
     (app::screen_size().1 / 2.0 - 200.0) as i32
 }
 
-#[derive(Debug, Clone)]
 pub struct Editor {
     pub editor: text::TextEditor,
     filename: String,

--- a/fltk/examples/editor.rs
+++ b/fltk/examples/editor.rs
@@ -6,13 +6,8 @@ use std::{
 };
 
 #[inline(always)]
-pub fn dlg_x() -> i32 {
-    (app::screen_size().0 / 2.0 - 200.0) as i32
-}
-
-#[inline(always)]
-pub fn dlg_y() -> i32 {
-    (app::screen_size().1 / 2.0 - 200.0) as i32
+pub fn center() -> (i32, i32) {
+    ((app::screen_size().0 / 2.0) as i32, (app::screen_size().1 / 2.0) as i32)
 }
 
 pub struct Editor {
@@ -31,6 +26,11 @@ impl Editor {
         e.editor.resize(5, 5, 790, 590);
 
         e.editor.set_buffer(Some(buf));
+        e.editor.set_text_font(Font::Courier);
+        e.editor.set_linenumber_width(32);
+        e.editor
+            .set_linenumber_fgcolor(Color::from_u32(0x8b8386));
+        e.editor.set_trigger(CallbackTrigger::Changed);
         e
     }
 
@@ -40,14 +40,6 @@ impl Editor {
 
     pub fn set_filename(&mut self, name: &str) {
         self.filename = String::from(name);
-    }
-
-    pub fn style(&mut self) {
-        self.editor.set_text_font(Font::Courier);
-        self.editor.set_linenumber_width(32);
-        self.editor
-            .set_linenumber_fgcolor(Color::from_u32(0x8b8386));
-        self.editor.set_trigger(CallbackTrigger::Changed);
     }
 
     pub fn save_file(&mut self, saved: &mut bool) -> Result<(), Box<dyn error::Error>> {
@@ -64,7 +56,7 @@ impl Editor {
                             self.editor.buffer().unwrap().save_file(&filename)?;
                             *saved = true;
                         }
-                        false => dialog::alert(dlg_x(), dlg_y(), "Please specify a file!"),
+                        false => dialog::alert(center().0 - 200, center().1 - 100, "Please specify a file!"),
                     }
                 }
             } else {
@@ -73,7 +65,7 @@ impl Editor {
                         self.editor.buffer().unwrap().save_file(&filename)?;
                         *saved = true;
                     }
-                    false => dialog::alert(dlg_x(), dlg_y(), "Please specify a file!"),
+                    false => dialog::alert(center().0 - 200, center().1 - 100, "Please specify a file!"),
                 }
             }
         } else {
@@ -87,7 +79,7 @@ impl Editor {
                         self.editor.buffer().unwrap().save_file(&filename)?;
                         *saved = true;
                     }
-                    false => dialog::alert(dlg_x(), dlg_y(), "Please specify a file!"),
+                    false => dialog::alert(center().0 - 200, center().1 - 100, "Please specify a file!"),
                 }
             }
         }
@@ -126,9 +118,9 @@ pub enum Message {
 fn main() {
     panic::set_hook(Box::new(|info| {
         if let Some(s) = info.payload().downcast_ref::<&str>() {
-            dialog::message(dlg_x(), dlg_y(), s);
+            dialog::message(center().0 - 200, center().1 - 100, s);
         } else {
-            dialog::message(dlg_x(), dlg_y(), &info.to_string());
+            dialog::message(center().0 - 200, center().1 - 100, &info.to_string());
         }
     }));
     
@@ -151,7 +143,6 @@ fn main() {
     buf.set_tab_distance(4);
 
     let mut editor = Editor::new(buf);
-    editor.style();
 
     editor.emit(s, Message::Changed);
 
@@ -292,7 +283,7 @@ fn main() {
                 Changed => saved = false,
                 New => {
                     if editor.buffer().unwrap().text() != "" {
-                        let x = dialog::choice(dlg_x(), dlg_y(), "File unsaved, Do you wish to continue?", "Yes", "No!", "");
+                        let x = dialog::choice(center().0 - 200, center().1 - 100, "File unsaved, Do you wish to continue?", "Yes", "No!", "");
                         if x == 0 {
                             editor.buffer().unwrap().set_text("");
                         }
@@ -309,7 +300,7 @@ fn main() {
                     if !filename.is_empty() {
                         match path::Path::new(&filename).exists() {
                             true => editor.buffer().unwrap().load_file(&filename).unwrap(),
-                            false => dialog::alert(dlg_x(), dlg_y(), "File does not exist!"),
+                            false => dialog::alert(center().0 - 200, center().1 - 100, "File does not exist!"),
                         }
                     }
                 },
@@ -317,7 +308,7 @@ fn main() {
                 SaveAs => editor.save_file(&mut false).unwrap(),
                 Quit => {
                     if !saved {
-                        let x = dialog::choice(dlg_x(), dlg_y(), "Would you like to save your work?", "Yes", "No", "");
+                        let x = dialog::choice(center().0 - 200, center().1 - 100, "Would you like to save your work?", "Yes", "No", "");
                         if x == 0 {
                             editor.save_file(&mut saved).unwrap();
                             app.quit();
@@ -331,7 +322,7 @@ fn main() {
                 Cut => editor.cut(),
                 Copy => editor.copy(),
                 Paste => editor.paste(),
-                About => dialog::message(dlg_x(), dlg_y(), "This is an example application written in Rust and using the FLTK Gui library."),
+                About => dialog::message(center().0 - 300, center().1 - 100, "This is an example application written in Rust and using the FLTK Gui library."),
             }
         }
     }

--- a/fltk/examples/editor.rs
+++ b/fltk/examples/editor.rs
@@ -129,14 +129,14 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     panic::set_hook(Box::new(|info| {
         if let Some(s) = info.payload().downcast_ref::<&str>() {
             dialog::message(
-                (app::screen_size().0 / 2.0) as i32 - 200,
-                (app::screen_size().1 / 2.0) as i32 - 100,
+                dlg_x(),
+                dlg_y(),
                 s,
             );
         } else {
             dialog::message(
-                (app::screen_size().0 / 2.0) as i32 - 200,
-                (app::screen_size().1 / 2.0) as i32 - 100,
+                dlg_x(),
+                dlg_y(),
                 &info.to_string(),
             );
         }
@@ -172,10 +172,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         buf.load_file(&args[1]).unwrap();
         editor.set_filename(&args[1]);
     }
-
-    // Handle drag and drop
-    let mut dnd = false;
-    let mut released = false;
 
     menu.add_emit(
         "&File/New...\t",
@@ -262,6 +258,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         }
     });
 
+    
+    // Handle drag and drop
+    let mut dnd = false;
+    let mut released = false;
+
     editor.handle(move |ev| match ev {
         Event::DndEnter => {
             dnd = true;
@@ -325,7 +326,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 SaveAs => editor.save_file(&mut false),
                 Quit => {
                     if !saved {
-                        let x = dialog::choice((app::screen_size().0 / 2.0) as i32 - 200, (app::screen_size().1 / 2.0) as i32 - 100, "Would you like to save your work?", "Yes", "No", "");
+                        let x = dialog::choice(dlg_x(), dlg_y(), "Would you like to save your work?", "Yes", "No", "");
                         if x == 0 {
                             editor.save_file(&mut saved);
                             app.quit();

--- a/fltk/examples/editor.rs
+++ b/fltk/examples/editor.rs
@@ -160,7 +160,7 @@ fn main() {
 
     if args.len() > 1 {
         let file = path::Path::new(&args[1]);
-        assert!(file.exists() && file.is_file());
+        assert!(file.exists() && file.is_file(), "An error occured while opening the file!");
         buf.load_file(&args[1]).unwrap();
         editor.set_filename(&args[1]);
     }

--- a/fltk/examples/printer.rs
+++ b/fltk/examples/printer.rs
@@ -10,15 +10,15 @@ fn main() {
     but.set_callback2(|widget| {
         let mut printer = printer::Printer::default();
         if printer.begin_job(1).is_ok() {
-            printer.begin_page().unwrap();
-            let (width, height) = printer.printable_rect().unwrap();
+            printer.begin_page();
+            let (width, height) = printer.printable_rect();
             draw::set_draw_color(Color::Black);
             draw::set_line_style(draw::LineStyle::Solid, 2);
             draw::draw_rect(0, 0, width, height);
             draw::set_font(Font::Courier, 12);
             printer.set_origin(width / 2, height / 2);
             printer.print_widget(widget, -widget.width() / 2, -widget.height() / 2);
-            printer.end_page().unwrap();
+            printer.end_page();
             printer.end_job();
         }
     });

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -9,7 +9,7 @@ use std::{
     ffi::{CStr, CString},
     marker, mem,
     os::raw,
-    panic, path, process, ptr, time,
+    panic, path, ptr, time,
 };
 
 pub type WidgetPtr = *mut fltk_sys::widget::Fl_Widget;
@@ -219,7 +219,7 @@ impl App {
     }
 
     /// Quit the application
-    pub fn quit(&self) -> ! {
+    pub fn quit(&self) {
         quit()
     }
 }
@@ -617,7 +617,7 @@ pub fn next_window<W: WindowExt>(w: &W) -> Option<impl WindowExt> {
 }
 
 /// Quit the app
-pub fn quit() -> ! {
+pub fn quit() {
     unsafe {
         if let Some(loaded_font) = LOADED_FONT {
             // Shouldn't fail
@@ -631,7 +631,6 @@ pub fn quit() -> ! {
             }
         }
     }
-    process::exit(0);
 }
 
 /// Adds a one-shot timeout callback. The timeout duration `tm` is indicated in seconds

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -527,7 +527,7 @@ pub fn width2(txt: &str, n: i32) -> f64 {
     unsafe { Fl_width2(txt.as_ptr(), n) }
 }
 
-/// Measure the length of text
+/// Measure the width and height of a text
 pub fn measure(txt: &str, draw_symbols: bool) -> (i32, i32) {
     let txt = CString::safe_new(txt);
     let mut x = 0;

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -527,6 +527,17 @@ pub fn width2(txt: &str, n: i32) -> f64 {
     unsafe { Fl_width2(txt.as_ptr(), n) }
 }
 
+/// Measure the length of text
+pub fn measure(txt: &str, draw_symbols: bool) -> (i32, i32) {
+    let txt = CString::safe_new(txt);
+    let mut x = 0;
+    let mut y = 0;
+    unsafe {
+        Fl_measure(txt.as_ptr(), &mut x, &mut y, draw_symbols as i32);
+    }
+    (x, y)
+}
+
 /// Returns the typographical width of a single character
 pub fn char_width(c: char) -> f64 {
     unsafe { Fl_width3(c as u32) }

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -205,7 +205,6 @@ pub mod menu;
 pub mod misc;
 pub mod output;
 pub mod prelude;
-pub mod printer;
 pub mod surface;
 pub mod table;
 pub mod text;
@@ -214,6 +213,8 @@ pub(crate) mod utils;
 pub mod valuator;
 pub mod widget;
 pub mod window;
+#[cfg(not(target_os = "android"))]
+pub mod printer;
 
 pub use enums::*;
 pub use prelude::*;

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -85,7 +85,7 @@ pub unsafe trait WidgetExt {
     fn height(&self) -> i32;
     /// Returns the label of the widget
     fn label(&self) -> String;
-    /// Measures the label's x and y coordinates
+    /// Measures the label's width and height
     fn measure_label(&self) -> (i32, i32);
     /// transforms a widget to a base Fl_Widget, for internal use
     /// # Safety

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -85,6 +85,8 @@ pub unsafe trait WidgetExt {
     fn height(&self) -> i32;
     /// Returns the label of the widget
     fn label(&self) -> String;
+    /// Measures the label's x and y coordinates
+    fn measure_label(&self) -> (i32, i32);
     /// transforms a widget to a base Fl_Widget, for internal use
     /// # Safety
     /// Can return multiple mutable pointers to the same widget

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -89,43 +89,43 @@ pub unsafe trait WidgetExt {
     /// # Safety
     /// Can return multiple mutable pointers to the same widget
     unsafe fn as_widget_ptr(&self) -> *mut fltk_sys::widget::Fl_Widget;
-    /// Initialize to position x, y
+    /// Initialize to position x, y, (should only be called on initialization)
     fn with_pos(self, x: i32, y: i32) -> Self
     where
         Self: Sized;
-    /// Initialilze to dimensions width and height
+    /// Initialilze to dimensions width and height, (should only be called on initialization)
     fn with_size(self, width: i32, height: i32) -> Self
     where
         Self: Sized;
-    /// Initialize with label/title
+    /// Initialize with label/title, (should only be called on initialization)
     fn with_label(self, title: &str) -> Self
     where
         Self: Sized;
-    /// Sets the initial alignment of the widget
+    /// Sets the initial alignment of the widget, (should only be called on initialization)
     fn with_align(self, align: Align) -> Self
     where
         Self: Sized;
-    /// Positions the widget below w
+    /// Positions the widget below w, the size of w should be known
     fn below_of<W: WidgetExt>(self, w: &W, padding: i32) -> Self
     where
         Self: Sized;
-    /// Positions the widget above w
+    /// Positions the widget above w, the size of w should be known
     fn above_of<W: WidgetExt>(self, w: &W, padding: i32) -> Self
     where
         Self: Sized;
-    /// Positions the widget to the right of w
+    /// Positions the widget to the right of w, the size of w should be known
     fn right_of<W: WidgetExt>(self, w: &W, padding: i32) -> Self
     where
         Self: Sized;
-    /// Positions the widget to the left of w
+    /// Positions the widget to the left of w, the size of w should be known
     fn left_of<W: WidgetExt>(self, w: &W, padding: i32) -> Self
     where
         Self: Sized;
-    /// Positions the widget to the center of w
+    /// Positions the widget to the center of w, the size of w should be known
     fn center_of<W: WidgetExt>(self, w: &W) -> Self
     where
         Self: Sized;
-    /// Takes the size of w
+    /// Takes the size of w, the size of w should be known
     fn size_of<W: WidgetExt>(self, w: &W) -> Self
     where
         Self: Sized;
@@ -367,7 +367,7 @@ pub unsafe trait WindowExt: GroupExt {
     fn center_screen(self) -> Self
     where
         Self: Sized;
-    /// Makes a window modal
+    /// Makes a window modal, should be called before ```show```
     fn make_modal(&mut self, val: bool);
     /// Makes a window fullscreen
     fn fullscreen(&mut self, val: bool);
@@ -379,7 +379,7 @@ pub unsafe trait WindowExt: GroupExt {
     fn set_icon<T: ImageExt>(&mut self, image: Option<T>)
     where
         Self: Sized;
-    /// Make the window resizable
+    /// Make the window resizable, should be called before ```show```
     fn make_resizable(&mut self, val: bool);
     /// Sets the cursor style within the window
     /// Needs to be called after the window is shown

--- a/fltk/src/printer.rs
+++ b/fltk/src/printer.rs
@@ -53,13 +53,9 @@ impl Printer {
     }
 
     /// End the print page
-    pub fn end_page(&mut self) -> Result<(), FltkError> {
+    pub fn end_page(&mut self) {
         unsafe {
-            if Fl_Printer_end_page(self._inner) != 0 {
-                Err(FltkError::Internal(FltkErrorKind::FailedToRun))
-            } else {
-                Ok(())
-            }
+            Fl_Printer_end_page(self._inner);
         }
     }
 
@@ -69,26 +65,19 @@ impl Printer {
     }
 
     /// Begins a print page
-    pub fn begin_page(&mut self) -> Result<(), FltkError> {
+    pub fn begin_page(&mut self) {
         unsafe {
-            if Fl_Printer_begin_page(self._inner) != 0 {
-                Err(FltkError::Internal(FltkErrorKind::FailedToRun))
-            } else {
-                Ok(())
-            }
+            Fl_Printer_begin_page(self._inner);
         }
     }
 
     /// Returns the width and height of the printable rect
-    pub fn printable_rect(&self) -> Result<(i32, i32), FltkError> {
+    pub fn printable_rect(&self) -> (i32, i32) {
         unsafe {
             let mut x = 0;
             let mut y = 0;
-            if Fl_Printer_printable_rect(self._inner, &mut x, &mut y) != 0 {
-                Err(FltkError::Internal(FltkErrorKind::FailedToRun))
-            } else {
-                Ok((x, y))
-            }
+            Fl_Printer_printable_rect(self._inner, &mut x, &mut y);
+            (x, y)
         }
     }
 


### PR DESCRIPTION
- Patch fltk to fix behavior of Fl_Win32_At_Exit() with mingw toolchain.
- Fix android build which doesn't support Fl_Printer.
- Fix WidgetExt::with_size() resizability.
- Add WidgetExt::measure_label() and draw::measure().
- Simplified some return types in the printer module.