### PR TITLE
Fix building under Mageia 7 x86_64

### DIFF
--- a/fltk-sys/build.rs
+++ b/fltk-sys/build.rs
@@ -202,7 +202,17 @@ fn main() {
 
     println!(
         "cargo:rustc-link-search=native={}",
+        out_dir.join("lib64").display()
+    );
+
+    println!(
+        "cargo:rustc-link-search=native={}",
         out_dir.join("lib").join("Release").display()
+    );
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        out_dir.join("lib64").join("Release").display()
     );
 
     if !cfg!(feature = "fltk-shared") {


### PR DESCRIPTION
Hi,

When I tried to build fltk-rs 0.10.9 with my PC running Mageia 7 x86_64, it failed because some directories are named lib64 and not lib so the proposed patch adds those directories.

Best regards,

Nico.