### PR TITLE
fix WidgetExt::right_of

### DIFF
--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -833,8 +833,8 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
             fn right_of<W: WidgetExt>(mut self, w: &W, padding: i32) -> Self {
                 assert!(!w.was_deleted());
                 assert!(!self.was_deleted());
-                debug_assert!(self.width() != 0 && self.height() != 0, "right_of requires the size of the widget to be known!");
-                self.resize(w.x() + self.width() + padding, w.y(), self.width(), self.height());
+                debug_assert!(w.width() != 0 && w.height() != 0, "right_of requires the size of the widget to be known!");
+                self.resize(w.x() + w.width() + padding, w.y(), self.width(), self.height());
                 self
             }
 


### PR DESCRIPTION
Use width of `w` instead of `self` when calculating the x-position to the right of `w`