### PR TITLE
0.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       shell: bash
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --release
+      run: NUM_JOBS=4 cargo build --release
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: NUM_JOBS=4 cargo build --release
+      shell: bash
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,4 +23,4 @@ jobs:
       shell: bash
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --examples --verbose
+      run: NUM_JOBS=4 cargo build --examples --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,4 +23,5 @@ jobs:
       shell: bash
     - uses: actions/checkout@v2
     - name: Build
+      shell: bash
       run: NUM_JOBS=4 cargo build --examples --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog
 
-## [0.10.16] - 2020-11-29
+## [0.11.0] - 2020-11-29
 ### Changes
+- [BREAKING] Remove enums::Color::to_rgb and to_u32.
+- Add utils::rgb2hex and utils::hex2rgb.
+- Add draw::set_draw_rgb_color() and set_draw_hex_color().
 - Relax app::Message requirements to only be Send + Sync.
 - Add app::set_font(Font) to set global app font.
+- Add app::set_color(Color) to set the global app's background color.
+- Add app::visible_focus and set_visible_focus.
+- Fix WidgetExt::center_of() to account for special positioning within windows.
+- WidgetExt::as_window and as_group only require immutable ref to self.
+- Default Window to a DoubleWindow instead of single window for better performance.
 
 ## [0.10.15] - 2020-11-27
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.10.16] - 2020-11-29
+### Changes
+- Relax app::Message requirements to only be Send + Sync.
+- Add app::set_font(Font) to set global app font.
+
 ## [0.10.15] - 2020-11-27
 ### Changes
 - Add more fields to enums::Align.

--- a/FAQ.md
+++ b/FAQ.md
@@ -11,7 +11,7 @@ The first tutorial uses the fltk-bundled feature flag, which is only supported f
 If you're not running one of the aforementioned platforms, you'll have to remove the fltk-bundled feature flag in your Cargo.toml file:
 ```toml
 [dependencies]
-fltk = "^0.10"
+fltk = "^0.11"
 ```
 Furthermore, the fltk-bundled flag assumes you have curl and tar installed (for Windows, they're available in the Native Tools Command Prompt).
 
@@ -24,7 +24,7 @@ If you're building for the GNU toolchain, make sure that Make is also installed,
 If the linking fails because of this issue: https://github.com/rust-lang/rust/issues/47048 with older toolchains, it should work by using the fltk-shared feature (an issue with older compilers). Which would also generate a dynamic library which would need to be deployed with your application.
 ```toml
 [dependencies]
-fltk = { version = "^0.10", features = ["fltk-shared"] }
+fltk = { version = "^0.11", features = ["fltk-shared"] }
 ```
 
 ### Build fails on Arch linux because of pango or cairo?
@@ -43,6 +43,9 @@ $ export CXX=/usr/bin/clang++
 $ cargo run
 ```
 CMake caches the C++ compiler variable after it's first run, so if the above failed because of a previous run, you would have to run ```cargo clean``` or you can manually delete the CMakeCache.txt file in the build directory.
+
+### Can I accelerate the build speed?
+You can use the "use-ninja" feature flag if you have ninja installed. Or you can set the NUM_JOBS environment variable, which the cmake crate picks up and tries to parallelize the build.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Just add the following to your project's Cargo.toml file:
 
 ```toml
 [dependencies]
-fltk = "^0.10"
+fltk = "^0.11"
 ```
 
-The library is automatically built and statically linked to your binary. 
+The library is automatically built and statically linked to your binary.
 
-You can also enable ninja builds for a faster build of the C++ source using the "use-ninja" feature.
+For faster builds with the cmake crate, you can try setting the NUM_JOBS environment variable, or you can enable ninja builds for the C++ source using the "use-ninja" feature.
 
 An example hello world application:
 

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.10.15"
+version = "0.11.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -803,7 +803,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
                 }
             }
 
-            fn as_window(&mut self) -> Option<Box<dyn WindowExt>> {
+            fn as_window(&self) -> Option<Box<dyn WindowExt>> {
                 assert!(!self.was_deleted());
                 unsafe {
                     let ptr = #as_window(self._inner);
@@ -814,7 +814,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
                 }
             }
 
-            fn as_group(&mut self) -> Option<Box<dyn GroupExt>> {
+            fn as_group(&self) -> Option<Box<dyn GroupExt>> {
                 assert!(!self.was_deleted());
                 unsafe {
                     let ptr = #as_group(self._inner);
@@ -865,9 +865,11 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
                 let mut sh = self.height() as f64;
                 let mut ww = w.width() as f64;
                 let mut wh = w.height() as f64;
-                let mut x = (ww - sw) / 2.0;
-                let mut y = (wh - sh) / 2.0;
-                self.resize(x as i32 + w.x(), y as i32 + w.y(), self.width(), self.height());
+                let mut sx = (ww - sw) / 2.0;
+                let mut sy = (wh - sh) / 2.0;
+                let wx = if w.as_window().is_some() { 0 } else { w.x() };
+                let wy = if w.as_window().is_some() { 0 } else { w.y() };
+                self.resize(sx as i32 + wx, sy as i32 + wy, self.width(), self.height());
                 self.redraw();
                 self
             }

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.10.15"
+version = "0.11.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"

--- a/fltk-sys/src/draw.rs
+++ b/fltk-sys/src/draw.rs
@@ -269,7 +269,7 @@ extern "C" {
     pub fn Fl_end_offscreen();
 }
 extern "C" {
-    pub fn Fl_set_font(face: libc::c_int, fsize: libc::c_int);
+    pub fn Fl_set_draw_font(face: libc::c_int, fsize: libc::c_int);
 }
 extern "C" {
     pub fn Fl_font() -> libc::c_int;

--- a/fltk-sys/src/fl.rs
+++ b/fltk-sys/src/fl.rs
@@ -93,7 +93,22 @@ extern "C" {
     pub fn Fl_scheme() -> libc::c_int;
 }
 extern "C" {
+    pub fn Fl_scheme_string() -> *const libc::c_char;
+}
+extern "C" {
+    pub fn Fl_visible_focus() -> libc::c_int;
+}
+extern "C" {
+    pub fn Fl_set_visible_focus(arg1: libc::c_int);
+}
+extern "C" {
+    pub fn Fl_set_box_type(arg1: libc::c_int, arg2: libc::c_int);
+}
+extern "C" {
     pub fn Fl_get_rgb_color(r: libc::c_uchar, g: libc::c_uchar, b: libc::c_uchar) -> libc::c_uint;
+}
+extern "C" {
+    pub fn Fl_set_color(c: libc::c_uint, r: libc::c_uchar, g: libc::c_uchar, b: libc::c_uchar);
 }
 extern "C" {
     pub fn Fl_get_font(idx: libc::c_int) -> *const libc::c_char;

--- a/fltk-sys/src/fl.rs
+++ b/fltk-sys/src/fl.rs
@@ -102,6 +102,9 @@ extern "C" {
     pub fn Fl_set_fonts(c: *const libc::c_char) -> libc::c_uchar;
 }
 extern "C" {
+    pub fn Fl_set_font(arg1: libc::c_int, arg2: libc::c_int);
+}
+extern "C" {
     pub fn Fl_add_handler(
         ev_handler: ::core::option::Option<unsafe extern "C" fn(ev: libc::c_int) -> libc::c_int>,
     );

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.10.15"
+version = "0.11.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=0.10.15" }
-fltk-derive = { path = "../fltk-derive", version = "=0.10.15" }
+fltk-sys = { path = "../fltk-sys", version = "=0.11.0" }
+fltk-derive = { path = "../fltk-derive", version = "=0.11.0" }
 
 [features]
 default = []

--- a/fltk/examples/animations.rs
+++ b/fltk/examples/animations.rs
@@ -1,5 +1,3 @@
-// For windows, you might want to change the window to a DoubleWindow and remove the sleep from the event loop.
-
 use fltk::{app::*, frame::*, image::*, window::*};
 
 macro_rules! clock {() => ("<?xml version=\"1.0\" encoding=\"utf-8\"?>
@@ -31,7 +29,7 @@ macro_rules! clock {() => ("<?xml version=\"1.0\" encoding=\"utf-8\"?>
 
 fn main() {
     let app = App::default().with_scheme(Scheme::Gtk);
-    let mut wind = DoubleWindow::default()
+    let mut wind = Window::default()
         .with_label("svg test")
         .with_size(720, 486)
         .center_screen();
@@ -71,7 +69,7 @@ fn main() {
 
 // fn main() {
 //     let app = App::default();
-//     let mut wind = DoubleWindow::default()
+//     let mut wind = Window::default()
 //         .with_label("svg test")
 //         .with_size(720, 486)
 //         .center_screen();

--- a/fltk/examples/defaults.rs
+++ b/fltk/examples/defaults.rs
@@ -1,0 +1,36 @@
+use fltk::*;
+
+fn main() {
+    let (r, g, b) = utils::hex2rgb(0xfafdf3);
+
+    let app = app::App::default();
+
+    // global theming
+    app::set_color(r, g, b);
+    app::set_font(Font::Courier);
+    app::set_frame_type(FrameType::RFlatBox);
+    app::set_visible_focus(false);
+
+    // regular widget code
+    let mut win = window::Window::default().with_size(400, 300);
+    let _frame = frame::Frame::new(0, 0, 400, 200, "Defaults");
+    let mut pack = group::Pack::new(0, 250, 400, 50, "");
+    pack.set_type(group::PackType::Horizontal);
+    pack.set_spacing(80);
+    let mut but1 = button::Button::default()
+        .with_label("Button1");
+    but1.set_color(Color::Yellow);
+    let mut but2 = button::Button::default()
+        .with_label("Button2");
+    but2.set_color(Color::Yellow);
+    pack.end();
+    pack.auto_layout();
+
+    win.end();
+    win.show();
+
+    but1.set_callback(|| app::redraw());
+    but2.set_callback(|| app::redraw());
+    
+    app.run().unwrap();
+}

--- a/fltk/examples/editor.rs
+++ b/fltk/examples/editor.rs
@@ -147,7 +147,7 @@ fn main() {
     printable.set_frame(FrameType::NoBox);
     printable.set_scrollbar_width(0);
 
-    let mut wind = window::DoubleWindow::default()
+    let mut wind = window::Window::default()
         .with_size(800, 600)
         .center_screen()
         .with_label("RustyEd");

--- a/fltk/examples/paint.rs
+++ b/fltk/examples/paint.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 fn main() {
     let app = app::App::default().with_scheme(app::Scheme::Gtk);
 
-    let mut wind = DoubleWindow::new(100, 100, 800, 600, "RustyPainter");
+    let mut wind = Window::new(100, 100, 800, 600, "RustyPainter");
     let mut frame = Frame::new(5, 5, 790, 590, "");
     frame.set_color(Color::White);
     frame.set_frame(FrameType::DownBox);
@@ -35,7 +35,7 @@ fn main() {
         // println!("{:?}", ev);
         // println!("coords {:?}", app::event_coords());
         // println!("get mouse {:?}", app::get_mouse());
-        set_draw_color(Color::Red);
+        set_draw_rgb_color(255, 0, 0); // red
         set_line_style(LineStyle::Solid, 3);
 
         match ev {

--- a/fltk/examples/pong.rs
+++ b/fltk/examples/pong.rs
@@ -17,7 +17,7 @@ struct Ball {
 
 fn main() {
     let app = app::App::default();
-    let mut wind = window::DoubleWindow::default()
+    let mut wind = window::Window::default()
         .with_size(800, 600)
         .center_screen()
         .with_label("Pong!");

--- a/fltk/examples/rgb_redraw.rs
+++ b/fltk/examples/rgb_redraw.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 fn main() {
     let app = app::App::default();
-    let mut wind = window::DoubleWindow::new(100, 100, 400, 400, "Hello from rust");
+    let mut wind = window::Window::new(100, 100, 400, 400, "Hello from rust");
     let mut frame = frame::Frame::new(0, 0, 400, 400, "");
     wind.end();
     wind.show();

--- a/fltk/examples/spreadsheet.rs
+++ b/fltk/examples/spreadsheet.rs
@@ -28,7 +28,7 @@ impl CellData {
 
 fn main() {
     let app = app::App::default().with_scheme(app::Scheme::Gtk);
-    let mut wind = window::DoubleWindow::new(100, 100, 800, 600, "Spreadsheet");
+    let mut wind = window::Window::new(100, 100, 800, 600, "Spreadsheet");
     let mut table = table::Table::new(5, 5, 790, 590, "");
     // We need an input widget
     let mut inp = input::Input::new(0, 0, 0, 0, "");

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -16,6 +16,8 @@ pub type WidgetPtr = *mut fltk_sys::widget::Fl_Widget;
 
 static mut CURRENT_FONT: i32 = 0;
 
+static mut CURRENT_FRAME: i32 = 2;
+
 /// The fonts associated with the application
 pub(crate) static mut FONTS: Vec<String> = Vec::new();
 
@@ -423,10 +425,35 @@ pub unsafe fn set_raw_callback<W>(
     fltk_sys::widget::Fl_Widget_set_callback(widget.as_widget_ptr(), cb, data);
 }
 
-/// Initializes loaded fonts of a certain pattern ```name```
-pub fn set_fonts(name: &str) -> u8 {
-    let name = CString::safe_new(name);
-    unsafe { Fl_set_fonts(name.as_ptr() as *mut raw::c_char) as u8 }
+pub fn visible_focus() -> bool {
+    unsafe {
+        Fl_visible_focus() != 0
+    }
+}
+
+pub fn set_visible_focus(flag: bool) {
+    unsafe {
+        Fl_set_visible_focus(flag as i32)
+    }
+}
+
+/// Set the app's default frame type
+pub fn set_frame_type(new_frame: FrameType) {
+    unsafe {
+        let new_frame = new_frame as i32;
+        Fl_set_box_type(56, CURRENT_FRAME);
+        Fl_set_box_type(CURRENT_FRAME, new_frame);
+        Fl_set_box_type(new_frame, 56);
+        CURRENT_FRAME = new_frame;
+        // Fl_set_box_type(FrameType::UpBox as i32, new_frame as i32)
+    }
+}
+
+/// Sets the app's default background color
+pub fn set_color(r: u8, g: u8, b: u8) {
+    unsafe {
+        Fl_set_color(Color::FrameDefault as u32, r, g, b)
+    }
 }
 
 /// Set the app's font
@@ -438,6 +465,21 @@ pub fn set_font(new_font: Font) {
         Fl_set_font(new_font, CURRENT_FONT);
         CURRENT_FONT = new_font;
     }
+}
+
+/// Get the font's name
+pub fn get_font(font: Font) -> String {
+    unsafe {
+        CStr::from_ptr(Fl_get_font(font as i32))
+            .to_string_lossy()
+            .to_string()
+    }
+}
+
+/// Initializes loaded fonts of a certain pattern ```name```
+pub fn set_fonts(name: &str) -> u8 {
+    let name = CString::safe_new(name);
+    unsafe { Fl_set_fonts(name.as_ptr() as *mut raw::c_char) as u8 }
 }
 
 /// Gets the name of a font through its index

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -194,8 +194,19 @@ pub fn draw_focus_rect(x: i32, y: i32, w: i32, h: i32) {
 }
 
 /// Sets the drawing color
+pub fn set_draw_hex_color(color: u32) {
+    let (r, g, b) = crate::utils::hex2rgb(color);
+    unsafe { Fl_set_color_rgb(r, g, b) }
+}
+
+/// Sets the drawing color
+pub fn set_draw_rgb_color(r: u8, g: u8, b: u8) {
+    unsafe { Fl_set_color_rgb(r, g, b) }
+}
+
+/// Sets the drawing color
 pub fn set_draw_color(color: Color) {
-    unsafe { Fl_set_color_int(color.to_u32()) }
+    unsafe { Fl_set_color_int(color as u32) }
 }
 
 /// Draws a circle

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -484,7 +484,7 @@ pub fn end_complex_polygon() {
 
 /// Sets the current font, which is then used in various drawing routines
 pub fn set_font(face: Font, fsize: u32) {
-    unsafe { Fl_set_font(face as i32, fsize as i32) }
+    unsafe { Fl_set_draw_font(face as i32, fsize as i32) }
 }
 
 /// Gets the current font, which is used in various drawing routines

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -198,26 +198,8 @@ impl Color {
 
     /// Returns a color from hex or decimal
     pub fn from_u32(val: u32) -> Color {
-        let hex = format!("{:06x}", val);
-        let r = u8::from_str_radix(&hex[0..2], 16).unwrap();
-        let g = u8::from_str_radix(&hex[2..4], 16).unwrap();
-        let b = u8::from_str_radix(&hex[4..6], 16).unwrap();
+        let (r, g, b) = crate::utils::hex2rgb(val);
         Color::from_rgb(r, g, b)
-    }
-
-    /// Returns the hex/u32 value of a color
-    pub fn to_u32(&self) -> u32 {
-        *self as u32
-    }
-
-    /// Returns the rgb values of a color
-    pub fn to_rgb(&self) -> (u8, u8, u8) {
-        let x = *self as u32;
-        let hex = format!("{:06x}", x);
-        let r = u8::from_str_radix(&hex[0..2], 16).unwrap();
-        let g = u8::from_str_radix(&hex[2..4], 16).unwrap();
-        let b = u8::from_str_radix(&hex[4..6], 16).unwrap();
-        (r, g, b)
     }
 }
 

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -279,9 +279,8 @@ impl ColorChooser {
     /// Return the hex color
     pub fn hex_color(&self) -> u32 {
         assert!(!self.was_deleted());
-        let c = self.rgb_color();
-        let x = Color::from_rgb(c.0, c.1, c.2);
-        x.to_u32()
+        let (r, g, b) = self.rgb_color();
+        crate::utils::rgb2hex(r, g, b)
     }
 }
 

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -22,11 +22,12 @@
 //!
 //! ```toml
 //! [dependencies]
-//! fltk = "^0.10"
+//! fltk = "^0.11"
 //! ```
 //! The library is automatically built and statically linked to your binary.
 //!
-//! You can also enable ninja builds for a faster build of the C++ source using the "use-ninja" feature.
+//! For faster builds with the cmake crate, you can try setting the NUM_JOBS environment variable, 
+//! or you can enable ninja builds for the C++ source using the "use-ninja" feature.
 //!
 //! An example hello world application:
 //!
@@ -185,7 +186,6 @@
 //! ```
 //! $ apk add pango-dev fontconfig-dev libxinerama-dev libxfixes-dev libxcursor-dev
 //! ```
-//! If you have ninja-build installed, you can enable it using the "use-ninja" feature. This should accelerate build times significantly.
 //!
 //! ## FAQ
 //!
@@ -209,7 +209,7 @@ pub mod surface;
 pub mod table;
 pub mod text;
 pub mod tree;
-pub(crate) mod utils;
+pub mod utils;
 pub mod valuator;
 pub mod widget;
 pub mod window;

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -267,9 +267,9 @@ pub unsafe trait WidgetExt {
     /// Return the callback trigger
     fn trigger(&self) -> u32;
     /// Return the widget as a window if it's a window
-    fn as_window(&mut self) -> Option<Box<dyn WindowExt>>;
+    fn as_window(&self) -> Option<Box<dyn WindowExt>>;
     /// Return the widget as a group widget if it's a group widget
-    fn as_group(&mut self) -> Option<Box<dyn GroupExt>>;
+    fn as_group(&self) -> Option<Box<dyn GroupExt>>;
     /// INTERNAL: Retakes ownership of the user callback data
     /// # Safety
     /// Can return multiple mutable references to the user_data

--- a/fltk/src/utils.rs
+++ b/fltk/src/utils.rs
@@ -15,3 +15,26 @@ impl FlString for CString {
         }
     }
 }
+
+/// Convenience function to convert rgb to hex
+/// Example: 
+/// ```rust
+/// let ret = rgb2hex(0, 255, 0); println!("0x{:06x}", ret);
+/// ```
+pub fn rgb2hex(r: u8, g: u8, b: u8) -> u32 {
+    // Shouldn't fail
+    format!("0x{:02x}{:02x}{:02x}", r, g, b).parse().unwrap()
+}
+
+/// Convenience function to convert hex to rgb
+/// Example:
+/// ```rust
+/// let (r, g, b) = hex2rgb(0x000000);
+/// ```
+pub fn hex2rgb(val: u32) -> (u8, u8, u8) {
+    let hex = format!("{:06x}", val);
+    let r = u8::from_str_radix(&hex[0..2], 16).unwrap();
+    let g = u8::from_str_radix(&hex[2..4], 16).unwrap();
+    let b = u8::from_str_radix(&hex[4..6], 16).unwrap();
+    (r, g, b)
+}


### PR DESCRIPTION
- [BREAKING] Remove enums::Color::to_rgb and to_u32.
- Add utils::rgb2hex and utils::hex2rgb.
- Add draw::set_draw_rgb_color() and set_draw_hex_color().
- Relax app::Message requirements to only be Send + Sync.
- Add app::set_font(Font) to set global app font.
- Add app::set_color(Color) to set the global app's background color.
- Add app::visible_focus and set_visible_focus.
- Fix WidgetExt::center_of() to account for special positioning within windows.
- WidgetExt::as_window and as_group only require immutable ref to self.
- Default Window to a DoubleWindow instead of single window for better performance.