### PR TITLE
0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.11.0] - 2020-11-29
+## [0.11.1] - 2020-11-29
 ### Changes
 - [BREAKING] Remove enums::Color::to_rgb and to_u32.
 - Add utils::rgb2hex and utils::hex2rgb.

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -159,6 +159,13 @@ impl Font {
 }
 
 /// Defines colors used by FLTK
+/// Colors are stored as RGBI values, the last being the index for FLTK colors in this enum. 
+/// Colors in this enum don't have an RGB stored. However, custom colors have an RGB, and don't have an index.
+/// The RGBI can be acquired by casting the color to u32 and formatting it to ```0x{08x}```.
+/// The last 2 digits are the hexadecimal representation of the color in this enum.
+/// For example, Color::White, has a hex of 0x000000ff, ff being the 255 value of this enum. 
+/// A custom color like Color::from_u32(0x646464), will have an representation as 0x64646400,
+/// of which the final 00 indicates that it is not stored in this enum.
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Color {

--- a/fltk/src/utils.rs
+++ b/fltk/src/utils.rs
@@ -23,7 +23,7 @@ impl FlString for CString {
 /// ```
 pub fn rgb2hex(r: u8, g: u8, b: u8) -> u32 {
     // Shouldn't fail
-    format!("0x{:02x}{:02x}{:02x}", r, g, b).parse().unwrap()
+    u32::from_str_radix(&format!("{:02x}{:02x}{:02x}", r, g, b), 16).unwrap()
 }
 
 /// Convenience function to convert hex to rgb


### PR DESCRIPTION
- [BREAKING] Remove enums::Color::to_rgb and to_u32.
- Add utils::rgb2hex and utils::hex2rgb.
- Add draw::set_draw_rgb_color() and set_draw_hex_color().
- Relax app::Message requirements to only be Send + Sync.
- Add app::set_font(Font) to set global app font.
- Add app::set_color(Color) to set the global app's background color.
- Add app::visible_focus and set_visible_focus.
- Fix WidgetExt::center_of() to account for special positioning within windows.
- WidgetExt::as_window and as_group only require immutable ref to self.
- Default Window to a DoubleWindow instead of single window for better performance.