### PR TITLE
0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.11.4] - Unreleased
+### Changes
+- Use lazy_static for globals.
+
 ## [0.11.3] - 2020-11-30
 ### Changes
 - [BREAKING] Remove enums::Color::to_rgb and to_u32.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,13 @@
 # Changelog
 
-## [0.11.4] - Unreleased
-### Changes
-- Use lazy_static for globals.
-- Use bitflags for several enum types.
 
-## [0.11.3] - 2020-11-30
+## [0.11.4] - 2020-11-30
 ### Changes
 - [BREAKING] Remove enums::Color::to_rgb and to_u32.
 - [BREAKING] WidgetExt::trigger returns a CallbackTrigger instead of an int.
-- Add custom Debug implementation for Color.
+- Add custom Display implementation for Color.
+- Use lazy_static for globals.
+- Use bitflags for several enum types.
 - Add utils::rgb2hex and utils::hex2rgb.
 - Add draw::set_draw_rgb_color() and set_draw_hex_color().
 - Relax app::Message requirements to only be Send + Sync.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.11.4] - Unreleased
 ### Changes
 - Use lazy_static for globals.
+- Use bitflags for several enum types.
 
 ## [0.11.3] - 2020-11-30
 ### Changes

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
 # Roadmap
 
 ## Version 0.11.0
-- Remove the fltk-bundled feature?
+- Move towards 1.0.0

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.11.3"
+version = "0.11.4"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -14,5 +14,5 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-syn = "^1.0.48"
+syn = "^1.0.53"
 quote = "^1.0.7"

--- a/fltk-derive/src/button.rs
+++ b/fltk-derive/src/button.rs
@@ -32,7 +32,7 @@ pub fn impl_button_trait(ast: &DeriveInput) -> TokenStream {
             fn set_shortcut(&mut self, shortcut: Shortcut) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_shortcut(self._inner, shortcut as i32)
+                    #set_shortcut(self._inner, shortcut.bits() as i32)
                 }
             }
 

--- a/fltk-derive/src/display.rs
+++ b/fltk-derive/src/display.rs
@@ -279,7 +279,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
             fn set_text_color(&mut self, color: Color){
                 assert!(!self.was_deleted());
                 assert!(self.buffer().is_some());
-                unsafe { #set_text_color(self._inner, color as u32) }
+                unsafe { #set_text_color(self._inner, color.bits() as u32) }
             }
 
             fn text_size(&self) -> u32{
@@ -422,7 +422,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
                 let mut fonts: Vec<i32> = vec![];
                 let mut sizes: Vec<i32> = vec![];
                 for entry in entries.iter() {
-                    colors.push(entry.color as u32);
+                    colors.push(entry.color.bits() as u32);
                     fonts.push(entry.font.bits() as i32);
                     sizes.push(entry.size as i32);
                 }
@@ -441,7 +441,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
             fn set_cursor_color(&mut self, color: Color){
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_cursor_color(self._inner, color as u32)
+                    #set_cursor_color(self._inner, color.bits() as u32)
                 }
             }
 
@@ -636,7 +636,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
             fn set_linenumber_fgcolor(&mut self, color: Color) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_linenumber_fgcolor(self._inner, color as u32)
+                    #set_linenumber_fgcolor(self._inner, color.bits() as u32)
                 }
             }
 
@@ -650,7 +650,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
             fn set_linenumber_bgcolor(&mut self, color: Color) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_linenumber_bgcolor(self._inner, color as u32)
+                    #set_linenumber_bgcolor(self._inner, color.bits() as u32)
                 }
             }
 

--- a/fltk-derive/src/display.rs
+++ b/fltk-derive/src/display.rs
@@ -267,7 +267,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
             fn set_text_font(&mut self, font: Font) {
                 assert!(!self.was_deleted());
                 assert!(self.buffer().is_some());
-                unsafe { #set_text_font(self._inner, font as i32) }
+                unsafe { #set_text_font(self._inner, font.bits() as i32) }
             }
 
             fn text_color(&self) -> Color{
@@ -423,7 +423,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
                 let mut sizes: Vec<i32> = vec![];
                 for entry in entries.iter() {
                     colors.push(entry.color as u32);
-                    fonts.push(entry.font as i32);
+                    fonts.push(entry.font.bits() as i32);
                     sizes.push(entry.size as i32);
                 }
                 unsafe {
@@ -463,7 +463,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
             fn set_scrollbar_align(&mut self, align: Align){
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_scrollbar_align(self._inner, align as i32)
+                    #set_scrollbar_align(self._inner, align.bits() as i32)
                 }
             }
 
@@ -607,7 +607,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
             fn set_linenumber_font(&mut self, font: Font) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_linenumber_font(self._inner, font as i32)
+                    #set_linenumber_font(self._inner, font.bits() as i32)
                 }
             }
 
@@ -664,7 +664,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
             fn set_linenumber_align(&mut self, align: Align) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_linenumber_align(self._inner, align as i32)
+                    #set_linenumber_align(self._inner, align.bits() as i32)
                 }
             }
 

--- a/fltk-derive/src/input.rs
+++ b/fltk-derive/src/input.rs
@@ -219,7 +219,7 @@ pub fn impl_input_trait(ast: &DeriveInput) -> TokenStream {
             fn set_text_font(&mut self, font: Font) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_text_font(self._inner, font as i32)
+                    #set_text_font(self._inner, font.bits() as i32)
                 }
             }
 

--- a/fltk-derive/src/input.rs
+++ b/fltk-derive/src/input.rs
@@ -233,7 +233,7 @@ pub fn impl_input_trait(ast: &DeriveInput) -> TokenStream {
             fn set_text_color(&mut self, color: Color) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_text_color(self._inner, color as u32)
+                    #set_text_color(self._inner, color.bits() as u32)
                 }
             }
 

--- a/fltk-derive/src/menu.rs
+++ b/fltk-derive/src/menu.rs
@@ -78,7 +78,7 @@ pub fn impl_menu_trait(ast: &DeriveInput) -> TokenStream {
                     let a: *mut Box<dyn FnMut()> = Box::into_raw(Box::new(Box::new(cb)));
                     let data: *mut raw::c_void = a as *mut raw::c_void;
                     let callback: Fl_Callback = Some(shim);
-                    #add(self._inner, temp.as_ptr(), shortcut as i32, callback, data, flag as i32);
+                    #add(self._inner, temp.as_ptr(), shortcut.bits() as i32, callback, data, flag as i32);
                 }
             }
 
@@ -95,7 +95,7 @@ pub fn impl_menu_trait(ast: &DeriveInput) -> TokenStream {
                     let a: *mut Box<dyn FnMut(&mut Self)> = Box::into_raw(Box::new(Box::new(cb)));
                     let data: *mut raw::c_void = a as *mut raw::c_void;
                     let callback: Fl_Callback = Some(shim);
-                    #add(self._inner, temp.as_ptr(), shortcut as i32, callback, data, flag as i32);
+                    #add(self._inner, temp.as_ptr(), shortcut.bits() as i32, callback, data, flag as i32);
                 }
             }
 
@@ -111,7 +111,7 @@ pub fn impl_menu_trait(ast: &DeriveInput) -> TokenStream {
                     let a: *mut Box<dyn FnMut()> = Box::into_raw(Box::new(Box::new(cb)));
                     let data: *mut raw::c_void = a as *mut raw::c_void;
                     let callback: Fl_Callback = Some(shim);
-                    #insert(self._inner, idx as i32, temp.as_ptr(), shortcut as i32, callback, data, flag as i32);
+                    #insert(self._inner, idx as i32, temp.as_ptr(), shortcut.bits() as i32, callback, data, flag as i32);
                 }
             }
 
@@ -128,7 +128,7 @@ pub fn impl_menu_trait(ast: &DeriveInput) -> TokenStream {
                     let a: *mut Box<dyn FnMut(&mut Self)> = Box::into_raw(Box::new(Box::new(cb)));
                     let data: *mut raw::c_void = a as *mut raw::c_void;
                     let callback: Fl_Callback = Some(shim);
-                    #insert(self._inner, idx as i32, temp.as_ptr(), shortcut as i32, callback, data, flag as i32);
+                    #insert(self._inner, idx as i32, temp.as_ptr(), shortcut.bits() as i32, callback, data, flag as i32);
                 }
             }
 
@@ -210,7 +210,7 @@ pub fn impl_menu_trait(ast: &DeriveInput) -> TokenStream {
             fn set_text_font(&mut self, c: Font) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_text_font(self._inner, c as i32)
+                    #set_text_font(self._inner, c.bits() as i32)
                 }
             }
 

--- a/fltk-derive/src/menu.rs
+++ b/fltk-derive/src/menu.rs
@@ -239,7 +239,7 @@ pub fn impl_menu_trait(ast: &DeriveInput) -> TokenStream {
             fn set_text_color(&mut self, c: Color) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_text_color(self._inner, c as u32)
+                    #set_text_color(self._inner, c.bits() as u32)
                 }
             }
 

--- a/fltk-derive/src/table.rs
+++ b/fltk-derive/src/table.rs
@@ -407,7 +407,7 @@ pub fn impl_table_trait(ast: &DeriveInput) -> TokenStream {
             fn set_row_header_color(&mut self, val: Color) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_row_header_color(self._inner, val as u32)
+                    #set_row_header_color(self._inner, val.bits() as u32)
                 }
             }
 
@@ -421,7 +421,7 @@ pub fn impl_table_trait(ast: &DeriveInput) -> TokenStream {
             fn set_col_header_color(&mut self, val: Color) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    #set_col_header_color(self._inner, val as u32)
+                    #set_col_header_color(self._inner, val.bits() as u32)
                 }
             }
 

--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -560,7 +560,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
 
             fn set_label_font(&mut self, font: Font) {
                 assert!(!self.was_deleted());
-                unsafe { #set_label_font(self._inner, font as i32) }
+                unsafe { #set_label_font(self._inner, font.bits() as i32) }
             }
 
             fn label_size(&self) -> i32 {
@@ -624,13 +624,13 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
 
             fn set_align(&mut self, align: Align) {
                 assert!(!self.was_deleted());
-                unsafe { #set_align(self._inner, align as i32) }
+                unsafe { #set_align(self._inner, align.bits() as i32) }
             }
 
             fn set_trigger(&mut self, trigger: CallbackTrigger) {
                 assert!(!self.was_deleted());
                 unsafe {
-                    #set_trigger(self._inner, trigger as i32)
+                    #set_trigger(self._inner, trigger.bits() as i32)
                 }
             }
 

--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -540,7 +540,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
 
             fn set_color(&mut self, color: Color) {
                 assert!(!self.was_deleted());
-                unsafe { #set_color(self._inner, color as u32) }
+                unsafe { #set_color(self._inner, color.bits() as u32) }
             }
 
             fn label_color(&self) -> Color {
@@ -550,7 +550,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
 
             fn set_label_color(&mut self, color: Color) {
                 assert!(!self.was_deleted());
-                unsafe { #set_label_color(self._inner, color as u32) }
+                unsafe { #set_label_color(self._inner, color.bits() as u32) }
             }
 
             fn label_font(&self) -> Font {
@@ -663,7 +663,7 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
             fn set_selection_color(&mut self, color: Color) {
                 assert!(!self.was_deleted());
                 unsafe {
-                    #set_selection_color(self._inner, color as u32);
+                    #set_selection_color(self._inner, color.bits() as u32);
                 }
             }
 

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.11.3"
+version = "0.11.4"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=0.11.3" }
 fltk-derive = { path = "../fltk-derive", version = "=0.11.3" }
+lazy_static = "^1.4.0"
 
 [features]
 default = []

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.11.3"
+version = "0.11.4"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=0.11.3" }
-fltk-derive = { path = "../fltk-derive", version = "=0.11.3" }
+fltk-sys = { path = "../fltk-sys", version = "=0.11.4" }
+fltk-derive = { path = "../fltk-derive", version = "=0.11.4" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 fltk-sys = { path = "../fltk-sys", version = "=0.11.3" }
 fltk-derive = { path = "../fltk-derive", version = "=0.11.3" }
 lazy_static = "^1.4.0"
+bitflags = "^1.2.1"
 
 [features]
 default = []

--- a/fltk/examples/defaults.rs
+++ b/fltk/examples/defaults.rs
@@ -11,6 +11,9 @@ fn main() {
     app::set_frame_type(FrameType::RFlatBox);
     app::set_visible_focus(false);
 
+    let c = Color::Gray0;
+    println!("{}", c);
+
     // regular widget code
     let mut win = window::Window::default().with_size(400, 300);
     let _frame = frame::Frame::new(0, 0, 400, 200, "Defaults");

--- a/fltk/examples/defaults.rs
+++ b/fltk/examples/defaults.rs
@@ -11,9 +11,6 @@ fn main() {
     app::set_frame_type(FrameType::RFlatBox);
     app::set_visible_focus(false);
 
-    let c = Color::Gray0;
-    println!("{}", c);
-
     // regular widget code
     let mut win = window::Window::default().with_size(400, 300);
     let _frame = frame::Frame::new(0, 0, 400, 200, "Defaults");

--- a/fltk/examples/oldfilechooser.rs
+++ b/fltk/examples/oldfilechooser.rs
@@ -9,7 +9,11 @@ fn main() {
     wind.end();
     wind.show();
 
+    let opts = FileChooserType::Multi;
+    println!("{:?}", opts);
+
     but.set_callback(|| {
+        
         let file = file_chooser("Choose File", "*.rs", ".", true).unwrap();
         println!("{}", file);
 

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -454,7 +454,7 @@ pub fn set_frame_type(new_frame: FrameType) {
 
 /// Sets the app's default background color
 pub fn set_color(r: u8, g: u8, b: u8) {
-    unsafe { Fl_set_color(Color::FrameDefault as u32, r, g, b) }
+    unsafe { Fl_set_color(Color::FrameDefault.bits() as u32, r, g, b) }
 }
 
 /// Set the app's font

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -9,28 +9,37 @@ use std::{
     ffi::{CStr, CString},
     marker, mem,
     os::raw,
-    panic, path, ptr, time,
+    panic, path, ptr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex,
+    },
+    time,
 };
 
 pub type WidgetPtr = *mut fltk_sys::widget::Fl_Widget;
 
-static mut CURRENT_FONT: i32 = 0;
+lazy_static! {
+    /// The currently chosen font
+    static ref CURRENT_FONT: Mutex<i32> = Mutex::new(0);
 
-static mut CURRENT_FRAME: i32 = 2;
+    /// The currently chosen frame type
+    static ref CURRENT_FRAME: Mutex<i32> = Mutex::new(2);
 
-/// The fonts associated with the application
-pub(crate) static mut FONTS: Vec<String> = Vec::new();
+    /// Currently loaded fonts
+    static ref LOADED_FONT: Option<&'static str> = None;
 
-/// Basically a check for global locking
-pub(crate) static mut IS_INIT: bool = false;
+    /// Basically a check for global locking
+    static ref IS_INIT: AtomicBool = AtomicBool::new(false);
 
-/// Currently loaded fonts
-static mut LOADED_FONT: Option<&str> = None;
+    /// The fonts associated with the application
+    pub(crate) static ref FONTS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+}
 
 /// Runs the event loop
 pub fn run() -> Result<(), FltkError> {
     unsafe {
-        if !IS_INIT {
+        if !IS_INIT.load(Ordering::Relaxed) {
             init_all();
         }
         match Fl_run() {
@@ -153,9 +162,7 @@ impl App {
 
     /// Loads system fonts
     pub fn load_system_fonts(self) -> Self {
-        unsafe {
-            FONTS = get_font_names();
-        }
+        *FONTS.lock().unwrap() = get_font_names();
         self
     }
 
@@ -426,44 +433,39 @@ pub unsafe fn set_raw_callback<W>(
 }
 
 pub fn visible_focus() -> bool {
-    unsafe {
-        Fl_visible_focus() != 0
-    }
+    unsafe { Fl_visible_focus() != 0 }
 }
 
 pub fn set_visible_focus(flag: bool) {
-    unsafe {
-        Fl_set_visible_focus(flag as i32)
-    }
+    unsafe { Fl_set_visible_focus(flag as i32) }
 }
 
 /// Set the app's default frame type
 pub fn set_frame_type(new_frame: FrameType) {
     unsafe {
         let new_frame = new_frame as i32;
-        Fl_set_box_type(56, CURRENT_FRAME);
-        Fl_set_box_type(CURRENT_FRAME, new_frame);
+        let mut curr = CURRENT_FRAME.lock().unwrap();
+        Fl_set_box_type(56, *curr);
+        Fl_set_box_type(*curr, new_frame);
         Fl_set_box_type(new_frame, 56);
-        CURRENT_FRAME = new_frame;
-        // Fl_set_box_type(FrameType::UpBox as i32, new_frame as i32)
+        *curr = new_frame;
     }
 }
 
 /// Sets the app's default background color
 pub fn set_color(r: u8, g: u8, b: u8) {
-    unsafe {
-        Fl_set_color(Color::FrameDefault as u32, r, g, b)
-    }
+    unsafe { Fl_set_color(Color::FrameDefault as u32, r, g, b) }
 }
 
 /// Set the app's font
 pub fn set_font(new_font: Font) {
     unsafe {
         let new_font = new_font as i32;
-        Fl_set_font(15, CURRENT_FONT);
+        let mut f = CURRENT_FONT.lock().unwrap();
+        Fl_set_font(15, *f);
         Fl_set_font(0, new_font);
-        Fl_set_font(new_font, CURRENT_FONT);
-        CURRENT_FONT = new_font;
+        Fl_set_font(new_font, *f);
+        *f = new_font;
     }
 }
 
@@ -484,7 +486,8 @@ pub fn set_fonts(name: &str) -> u8 {
 
 /// Gets the name of a font through its index
 pub fn font_name(idx: usize) -> Option<String> {
-    unsafe { Some(FONTS[idx].clone()) }
+    let f = FONTS.lock().unwrap();
+    Some(f[idx].clone())
 }
 
 /// Returns a list of available fonts to the application
@@ -504,17 +507,18 @@ pub fn get_font_names() -> Vec<String> {
 
 /// Finds the index of a font through its name
 pub fn font_index(name: &str) -> Option<usize> {
-    unsafe { FONTS.iter().position(|i| i == name) }
+    let f = FONTS.lock().unwrap();
+    f.iter().position(|i| i == name)
 }
 
 /// Gets the number of loaded fonts
 pub fn font_count() -> usize {
-    unsafe { FONTS.len() }
+    (*FONTS.lock().unwrap()).len()
 }
 
 /// Gets a Vector<String> of loaded fonts
 pub fn fonts() -> Vec<String> {
-    unsafe { FONTS.clone() }
+    (*FONTS.lock().unwrap()).clone()
 }
 
 /// Adds a custom handler for unhandled events
@@ -531,7 +535,7 @@ pub fn add_handler(cb: fn(Event) -> bool) {
 /// Starts waiting for events
 pub fn wait() -> bool {
     unsafe {
-        if !IS_INIT {
+        if !IS_INIT.load(Ordering::Relaxed) {
             init_all();
         }
         Fl_wait() != 0
@@ -541,7 +545,7 @@ pub fn wait() -> bool {
 /// Waits a maximum of `dur` seconds or until "something happens".
 pub fn wait_for(dur: f64) -> Result<(), FltkError> {
     unsafe {
-        if !IS_INIT {
+        if !IS_INIT.load(Ordering::Relaxed) {
             init_all();
         }
         if Fl_wait_for(dur) >= 0.0 {
@@ -673,11 +677,9 @@ pub fn next_window<W: WindowExt>(w: &W) -> Option<impl WindowExt> {
 
 /// Quit the app
 pub fn quit() {
-    unsafe {
-        if let Some(loaded_font) = LOADED_FONT {
-            // Shouldn't fail
-            unload_font(loaded_font).unwrap_or(());
-        }
+    if let Some(loaded_font) = *LOADED_FONT {
+        // Shouldn't fail
+        unload_font(loaded_font).unwrap_or(());
     }
     if let Some(wins) = windows() {
         for mut i in wins {
@@ -810,7 +812,7 @@ pub fn init_all() {
         lock().expect("fltk-rs requires threading support!");
         register_images();
         // This should never appear!
-        FONTS = vec![
+        *FONTS.lock().unwrap() = vec![
             "Helvetica".to_owned(),
             "HelveticaBold".to_owned(),
             "HelveticaItalic".to_owned(),
@@ -828,8 +830,8 @@ pub fn init_all() {
             "ScreenBold".to_owned(),
             "Zapfdingbats".to_owned(),
         ];
-        if !IS_INIT {
-            IS_INIT = true;
+        if !IS_INIT.load(Ordering::Relaxed) {
+            IS_INIT.store(true, Ordering::Relaxed);
         }
     }
 }
@@ -985,7 +987,7 @@ pub fn dnd() {
 fn load_font(path: &str) -> Result<String, FltkError> {
     unsafe {
         let path = CString::new(path)?;
-        if let Some(load_font) = LOADED_FONT {
+        if let Some(load_font) = *LOADED_FONT {
             unload_font(load_font)?;
         }
         let ptr = Fl_load_font(path.as_ptr());
@@ -995,10 +997,11 @@ fn load_font(path: &str) -> Result<String, FltkError> {
             let name = CString::from_raw(ptr as *mut _)
                 .to_string_lossy()
                 .to_string();
-            if FONTS.len() < 17 {
-                FONTS.push(name.clone());
+            let mut f = FONTS.lock().unwrap();
+            if f.len() < 17 {
+                f.push(name.clone());
             } else {
-                FONTS[16] = name.clone();
+                f[16] = name.clone();
             }
             Ok(name)
         }

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -460,7 +460,7 @@ pub fn set_color(r: u8, g: u8, b: u8) {
 /// Set the app's font
 pub fn set_font(new_font: Font) {
     unsafe {
-        let new_font = new_font as i32;
+        let new_font = new_font.bits() as i32;
         let mut f = CURRENT_FONT.lock().unwrap();
         Fl_set_font(15, *f);
         Fl_set_font(0, new_font);
@@ -472,7 +472,7 @@ pub fn set_font(new_font: Font) {
 /// Get the font's name
 pub fn get_font(font: Font) -> String {
     unsafe {
-        CStr::from_ptr(Fl_get_font(font as i32))
+        CStr::from_ptr(Fl_get_font(font.bits() as i32))
             .to_string_lossy()
             .to_string()
     }
@@ -874,7 +874,7 @@ pub fn damage() -> bool {
 /// Sets the visual mode of the application
 pub fn set_visual(mode: Mode) -> Result<(), FltkError> {
     unsafe {
-        match Fl_visual(mode as i32) {
+        match Fl_visual(mode.bits() as i32) {
             0 => Err(FltkError::Internal(FltkErrorKind::FailedOperation)),
             _ => Ok(()),
         }

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -405,34 +405,13 @@ pub struct FileChooser {
     _inner: *mut Fl_File_Chooser,
 }
 
-/// The types of FileChooser
-#[repr(i32)]
-#[derive(Copy, Clone, PartialEq)]
-pub enum FileChooserType {
-    Single = 0,
-    Multi = 1,
-    Create = 2,
-    Directory = 4,
-}
-
-#[allow(unreachable_patterns)]
-impl std::fmt::Debug for FileChooserType {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use FileChooserType::*;
-        match *self {
-            Single => write!(f, "FileChooserType::Single"),
-            Multi => write!(f, "FileChooserType::Multi"),
-            Create => write!(f, "FileChooserType::Create"),
-            Directory => write!(f, "FileChooserType::Directory"),
-            _ => write!(f, "0x{:02x}", *self as i32),
-        }
-    }
-}
-
-impl std::ops::BitOr<FileChooserType> for FileChooserType {
-    type Output = FileChooserType;
-    fn bitor(self, other: FileChooserType) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | other as i32) }
+bitflags! {
+    /// The types of FileChooser
+    pub struct FileChooserType: i32 {
+        const Single = 0;
+        const Multi = 1;
+        const Create = 2;
+        const Directory = 4;
     }
 }
 
@@ -444,7 +423,7 @@ impl FileChooser {
         let title = CString::safe_new(title);
         unsafe {
             let ptr =
-                Fl_File_Chooser_new(dir.as_ptr(), pattern.as_ptr(), typ as i32, title.as_ptr());
+                Fl_File_Chooser_new(dir.as_ptr(), pattern.as_ptr(), typ.bits as i32, title.as_ptr());
             assert!(!ptr.is_null());
             FileChooser { _inner: ptr }
         }
@@ -731,7 +710,7 @@ impl FileChooser {
     /// Sets the text font of the file chooser
     pub fn set_textfont(&mut self, f: Font) {
         assert!(!self._inner.is_null());
-        unsafe { Fl_File_Chooser_set_textfont(self._inner, f as i32) }
+        unsafe { Fl_File_Chooser_set_textfont(self._inner, f.bits() as i32) }
     }
 
     /// Gets the text font of the file chooser
@@ -755,7 +734,7 @@ impl FileChooser {
     /// Sets the type of the FileChooser
     pub fn set_type(&mut self, t: FileChooserType) {
         assert!(!self._inner.is_null());
-        unsafe { Fl_File_Chooser_set_type(self._inner, t as i32) }
+        unsafe { Fl_File_Chooser_set_type(self._inner, t.bits as i32) }
     }
 
     /// Gets the type of the FileChooser

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -522,7 +522,7 @@ impl FileChooser {
     /// Sets the color of the FileChooser
     pub fn set_color(&mut self, c: Color) {
         assert!(!self._inner.is_null());
-        unsafe { Fl_File_Chooser_set_color(self._inner, c as u32) }
+        unsafe { Fl_File_Chooser_set_color(self._inner, c.bits() as u32) }
     }
 
     /// Gets the color of the FileChooser
@@ -698,7 +698,7 @@ impl FileChooser {
     /// Sets the text color of the file chooser
     pub fn set_textcolor(&mut self, c: Color) {
         assert!(!self._inner.is_null());
-        unsafe { Fl_File_Chooser_set_textcolor(self._inner, c as u32) }
+        unsafe { Fl_File_Chooser_set_textcolor(self._inner, c.bits() as u32) }
     }
 
     /// Gets the text color of the file chooser

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -495,7 +495,7 @@ pub fn end_complex_polygon() {
 
 /// Sets the current font, which is then used in various drawing routines
 pub fn set_font(face: Font, fsize: u32) {
-    unsafe { Fl_set_draw_font(face as i32, fsize as i32) }
+    unsafe { Fl_set_draw_font(face.bits() as i32, fsize as i32) }
 }
 
 /// Gets the current font, which is used in various drawing routines
@@ -516,7 +516,7 @@ pub fn height() -> i32 {
 /// Sets the line spacing for the current font
 pub fn set_height(font: Font, size: u32) {
     unsafe {
-        Fl_set_height(font as i32, size as i32);
+        Fl_set_height(font.bits() as i32, size as i32);
     }
 }
 
@@ -587,7 +587,7 @@ pub fn draw_text(txt: &str, x: i32, y: i32) {
 /// Draws a string starting at the given x, y location with width and height and alignment
 pub fn draw_text2(string: &str, x: i32, y: i32, width: i32, height: i32, align: Align) {
     let s = CString::safe_new(string);
-    unsafe { Fl_draw_text2(s.as_ptr(), x, y, width, height, align as i32) }
+    unsafe { Fl_draw_text2(s.as_ptr(), x, y, width, height, align.bits() as i32) }
 }
 
 /// Draws a string starting at the given x, y location, rotated to an angle
@@ -634,7 +634,7 @@ pub fn can_do_alpha_blending() -> bool {
 /// Get a human-readable string from a shortcut value
 pub fn shortcut_label(shortcut: Shortcut) -> String {
     unsafe {
-        let x = Fl_shortcut_label(shortcut as u32);
+        let x = Fl_shortcut_label(shortcut.bits() as u32);
         assert!(!x.is_null());
         CStr::from_ptr(x as *mut raw::c_char)
             .to_string_lossy()
@@ -672,7 +672,7 @@ pub fn set_spot<Win: WindowExt>(font: Font, size: u32, x: i32, y: i32, w: i32, h
     unsafe {
         assert!(!win.was_deleted());
         Fl_set_spot(
-            font as i32,
+            font.bits() as i32,
             size as i32,
             x,
             y,

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -117,7 +117,7 @@ impl Drop for Offscreen {
 
 /// Shows a color map
 pub fn show_colormap(old_color: Color) -> Color {
-    unsafe { mem::transmute(Fl_show_colormap(old_color as u32)) }
+    unsafe { mem::transmute(Fl_show_colormap(old_color.bits() as u32)) }
 }
 
 /// Sets the color using rgb values
@@ -159,7 +159,7 @@ pub fn draw_rect(x: i32, y: i32, w: i32, h: i32) {
 
 /// Draws a rectangle with border color
 pub fn draw_rect_with_color(x: i32, y: i32, w: i32, h: i32, color: Color) {
-    unsafe { Fl_rect_with_color(x, y, w, h, color as u32) }
+    unsafe { Fl_rect_with_color(x, y, w, h, color.bits() as u32) }
 }
 
 /// Draws a non-filled 3-sided polygon
@@ -185,7 +185,7 @@ pub fn draw_loop3(pos1: Coord<i32>, pos2: Coord<i32>, pos3: Coord<i32>, pos4: Co
 
 /// Draws a filled rectangle
 pub fn draw_rect_fill(x: i32, y: i32, w: i32, h: i32, color: Color) {
-    unsafe { Fl_rectf_with_color(x, y, w, h, color as u32) }
+    unsafe { Fl_rectf_with_color(x, y, w, h, color.bits() as u32) }
 }
 
 /// Draws a focus rectangle
@@ -206,7 +206,7 @@ pub fn set_draw_rgb_color(r: u8, g: u8, b: u8) {
 
 /// Sets the drawing color
 pub fn set_draw_color(color: Color) {
-    unsafe { Fl_set_color_int(color as u32) }
+    unsafe { Fl_set_color_int(color.bits() as u32) }
 }
 
 /// Draws a circle
@@ -618,7 +618,7 @@ pub fn draw_frame2(string: &str, x: i32, y: i32, width: i32, height: i32) {
 
 /// Draws a box given the box type, size, position and color
 pub fn draw_box(box_type: FrameType, x: i32, y: i32, w: i32, h: i32, color: Color) {
-    unsafe { Fl_draw_box(box_type as i32, x, y, w, h, color as u32) }
+    unsafe { Fl_draw_box(box_type as i32, x, y, w, h, color.bits() as u32) }
 }
 
 /// Checks whether platform supports true alpha blending for RGBA images
@@ -659,7 +659,7 @@ pub fn set_cursor(cursor: Cursor) {
 
 /// Sets the cursor style
 pub fn set_cursor_with_color(cursor: Cursor, fg: Color, bg: Color) {
-    unsafe { Fl_set_cursor2(cursor as i32, fg as i32, bg as i32) }
+    unsafe { Fl_set_cursor2(cursor as i32, fg.bits() as i32, bg.bits() as i32) }
 }
 
 /// Sets the status

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -87,86 +87,54 @@ impl FrameType {
     }
 }
 
-/// Defines alignment rules used by FLTK for labels
-#[repr(i32)]
-#[derive(Copy, Clone, PartialEq)]
-pub enum Align {
-    Center = 0,
-    Top = 1,
-    Bottom = 2,
-    Left = 4,
-    Right = 8,
-    Inside = 16,
-    TextOverImage = 20,
-    Clip = 40,
-    Wrap = 80,
-    ImageNextToText = 100,
-    TextNextToImage = 120,
-    ImageBackdrop = 200,
-    TopLeft = 1 | 4,
-    TopRight = 1 | 8,
-    BottomLeft = 2 | 4,
-    BottomRight = 2 | 8,
-    LeftTop = 7,
-    RightTop = 11,
-    LeftBottom = 13,
-    RightBottom = 14,
-    PositionMask = 15,
-    ImageMask = 320,
-}
-
-#[allow(unreachable_patterns)]
-impl std::fmt::Debug for Align {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use Align::*;
-        match *self {
-            Center => write!(f, "Align::Center"),
-            Top => write!(f, "Align::Top"),
-            Bottom => write!(f, "Align::Bottom"),
-            Left => write!(f, "Align::Left"),
-            Right => write!(f, "Align::Right"),
-            Inside => write!(f, "Align::Inside"),
-            TextOverImage => write!(f, "Align::TextOverImage"),
-            Clip => write!(f, "Align::Clip"),
-            Wrap => write!(f, "Align::Wrap"),
-            ImageNextToText => write!(f, "Align::ImageNextToText"),
-            TextNextToImage => write!(f, "Align::TextNextToImage"),
-            ImageBackdrop => write!(f, "Align::ImageBackdrop"),
-            TopLeft => write!(f, "Align::TopLeft"),
-            TopRight => write!(f, "Align::TopRight"),
-            BottomLeft => write!(f, "Align::BottomLeft"),
-            BottomRight => write!(f, "Align::BottomRight"),
-            LeftTop => write!(f, "Align::LeftTop"),
-            RightTop => write!(f, "Align::RightTop"),
-            LeftBottom => write!(f, "Align::LeftBottom"),
-            RightBottom => write!(f, "Align::RightBottom"),
-            PositionMask => write!(f, "Align::PositionMask"),
-            ImageMask => write!(f, "Align::ImageMask"),
-            _ => write!(f, "0x{:02x}", *self as i32),
-        }
+bitflags! {
+    /// Defines alignment rules used by FLTK for labels
+    pub struct Align: i32 {
+        const Center = 0;
+        const Top = 1;
+        const Bottom = 2;
+        const Left = 4;
+        const Right = 8;
+        const Inside = 16;
+        const TextOverImage = 20;
+        const Clip = 40;
+        const Wrap = 80;
+        const ImageNextToText = 100;
+        const TextNextToImage = 120;
+        const ImageBackdrop = 200;
+        const TopLeft = 1 | 4;
+        const TopRight = 1 | 8;
+        const BottomLeft = 2 | 4;
+        const BottomRight = 2 | 8;
+        const LeftTop = 7;
+        const RightTop = 11;
+        const LeftBottom = 13;
+        const RightBottom = 14;
+        const PositionMask = 15;
+        const ImageMask = 320;
     }
 }
 
-/// Defines fonts used by FLTK
-#[repr(i32)]
-#[derive(Copy, Clone, PartialEq)]
-pub enum Font {
-    Helvetica = 0,
-    HelveticaBold = 1,
-    HelveticaItalic = 2,
-    HelveticaBoldItalic = 3,
-    Courier = 4,
-    CourierBold = 5,
-    CourierItalic = 6,
-    CourierBoldItalic = 7,
-    Times = 8,
-    TimesBold = 9,
-    TimesItalic = 10,
-    TimesBoldItalic = 11,
-    Symbol = 12,
-    Screen = 13,
-    ScreenBold = 14,
-    Zapfdingbats = 15,
+bitflags! {
+    /// Defines fonts used by FLTK
+    pub struct Font: i32 {
+        const Helvetica = 0;
+        const HelveticaBold = 1;
+        const HelveticaItalic = 2;
+        const HelveticaBoldItalic = 3;
+        const Courier = 4;
+        const CourierBold = 5;
+        const CourierItalic = 6;
+        const CourierBoldItalic = 7;
+        const Times = 8;
+        const TimesBold = 9;
+        const TimesItalic = 10;
+        const TimesBoldItalic = 11;
+        const Symbol = 12;
+        const Screen = 13;
+        const ScreenBold = 14;
+        const Zapfdingbats = 15;
+    }
 }
 
 impl Font {
@@ -186,33 +154,6 @@ impl Font {
         match font_index(name) {
             Some(val) => Font::by_index(val),
             None => Font::Helvetica,
-        }
-    }
-}
-
-
-#[allow(unreachable_patterns)]
-impl std::fmt::Debug for Font {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use Font::*;
-        match *self {
-            Helvetica => write!(f, "Font::Helvetica"),
-            HelveticaBold => write!(f, "Font::HelveticaBold"),
-            HelveticaItalic => write!(f, "Font::HelveticaItalic"),
-            HelveticaBoldItalic => write!(f, "Font::HelveticaBoldItalic"),
-            Courier => write!(f, "Font::Courier"),
-            CourierBold => write!(f, "Font::CourierBold"),
-            CourierItalic => write!(f, "Font::CourierItalic"),
-            CourierBoldItalic => write!(f, "Font::CourierBoldItalic"),
-            Times => write!(f, "Font::Times"),
-            TimesBold => write!(f, "Font::TimesBold"),
-            TimesItalic => write!(f, "Font::TimesItalic"),
-            TimesBoldItalic => write!(f, "Font::TimesBoldItalic"),
-            Symbol => write!(f, "Font::Symbol"),
-            Screen => write!(f, "Font::Screen"),
-            ScreenBold => write!(f, "Font::ScreenBold"),
-            Zapfdingbats => write!(f, "Font::Zapfdingbats"),
-            _ => write!(f, "0x{:02x}", *self as i32),
         }
     }
 }
@@ -339,51 +280,53 @@ pub enum Event {
     ZoomEvent,
 }
 
-/// Defines the inputted virtual keycode
-#[repr(i32)]
-#[derive(Copy, Clone, PartialEq)]
-pub enum Key {
-    None = 0,
-    Button = 0xfee8,
-    BackSpace = 0xff08,
-    Tab = 0xff09,
-    IsoKey = 0xff0c,
-    Enter = 0xff0d,
-    Pause = 0xff13,
-    ScrollLock = 0xff14,
-    Escape = 0xff1b,
-    Kana = 0xff2e,
-    Eisu = 0xff2f,
-    Yen = 0xff30,
-    JISUnderscore = 0xff31,
-    Home = 0xff50,
-    Left = 0xff51,
-    Up = 0xff52,
-    Right = 0xff53,
-    Down = 0xff54,
-    PageUp = 0xff55,
-    PageDown = 0xff56,
-    End = 0xff57,
-    Print = 0xff61,
-    Insert = 0xff63,
-    Menu = 0xff67,
-    Help = 0xff68,
-    NumLock = 0xff7f,
-    KP = 0xff80,
-    KPEnter = 0xff8d,
-    KPLast = 0xffbd,
-    FLast = 0xffe0,
-    ShiftL = 0xffe1,
-    ShiftR = 0xffe2,
-    ControlL = 0xffe3,
-    ControlR = 0xffe4,
-    CapsLock = 0xffe5,
-    MetaL = 0xffe7,
-    MetaR = 0xffe8,
-    AltL = 0xffe9,
-    AltR = 0xffea,
-    Delete = 0xffff,
+bitflags! {
+    /// Defines the inputted virtual keycode
+    pub struct Key: i32 {
+        const None = 0;
+        const Button = 0xfee8;
+        const BackSpace = 0xff08;
+        const Tab = 0xff09;
+        const IsoKey = 0xff0c;
+        const Enter = 0xff0d;
+        const Pause = 0xff13;
+        const ScrollLock = 0xff14;
+        const Escape = 0xff1b;
+        const Kana = 0xff2e;
+        const Eisu = 0xff2f;
+        const Yen = 0xff30;
+        const JISUnderscore = 0xff31;
+        const Home = 0xff50;
+        const Left = 0xff51;
+        const Up = 0xff52;
+        const Right = 0xff53;
+        const Down = 0xff54;
+        const PageUp = 0xff55;
+        const PageDown = 0xff56;
+        const End = 0xff57;
+        const Print = 0xff61;
+        const Insert = 0xff63;
+        const Menu = 0xff67;
+        const Help = 0xff68;
+        const NumLock = 0xff7f;
+        const KP = 0xff80;
+        const KPEnter = 0xff8d;
+        const KPLast = 0xffbd;
+        const FLast = 0xffe0;
+        const ShiftL = 0xffe1;
+        const ShiftR = 0xffe2;
+        const ControlL = 0xffe3;
+        const ControlR = 0xffe4;
+        const CapsLock = 0xffe5;
+        const MetaL = 0xffe7;
+        const MetaR = 0xffe8;
+        const AltL = 0xffe9;
+        const AltR = 0xffea;
+        const Delete = 0xffff;
+    }
 }
+
+
 
 impl Key {
     /// Gets a Key from an i32
@@ -397,65 +340,17 @@ impl Key {
     }
 }
 
-#[allow(unreachable_patterns)]
-impl std::fmt::Debug for Key {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match *self {
-            Key::None => write!(f, "Key::None"),
-            Key::Button => write!(f, "Key::Button"),
-            Key::BackSpace => write!(f, "Key::BackSpace"),
-            Key::Tab => write!(f, "Key::Tab"),
-            Key::IsoKey => write!(f, "Key::IsoKey"),
-            Key::Enter => write!(f, "Key::Enter"),
-            Key::Pause => write!(f, "Key::Pause"),
-            Key::ScrollLock => write!(f, "Key::ScrollLock"),
-            Key::Escape => write!(f, "Key::Escape"),
-            Key::Kana => write!(f, "Key::Kana"),
-            Key::Eisu => write!(f, "Key::Eisu"),
-            Key::Yen => write!(f, "Key::Yen"),
-            Key::JISUnderscore => write!(f, "Key::JISUnderscore"),
-            Key::Home => write!(f, "Key::Home"),
-            Key::Left => write!(f, "Key::Left"),
-            Key::Up => write!(f, "Key::Up"),
-            Key::Right => write!(f, "Key::Right"),
-            Key::Down => write!(f, "Key::Down"),
-            Key::PageUp => write!(f, "Key::PageUp"),
-            Key::PageDown => write!(f, "Key::PageDown"),
-            Key::End => write!(f, "Key::End"),
-            Key::Print => write!(f, "Key::Print"),
-            Key::Insert => write!(f, "Key::Insert"),
-            Key::Menu => write!(f, "Key::Menu"),
-            Key::Help => write!(f, "Key::Help"),
-            Key::NumLock => write!(f, "Key::NumLock"),
-            Key::KP => write!(f, "Key::KP"),
-            Key::KPEnter => write!(f, "Key::KPEnter"),
-            Key::KPLast => write!(f, "Key::KPLast"),
-            Key::FLast => write!(f, "Key::FLast"),
-            Key::ShiftL => write!(f, "Key::ShiftL"),
-            Key::ShiftR => write!(f, "Key::ShiftR"),
-            Key::ControlL => write!(f, "Key::ControlL"),
-            Key::ControlR => write!(f, "Key::ControlR"),
-            Key::CapsLock => write!(f, "Key::CapsLock"),
-            Key::MetaL => write!(f, "Key::MetaL"),
-            Key::MetaR => write!(f, "Key::MetaR"),
-            Key::AltL => write!(f, "Key::AltL"),
-            Key::AltR => write!(f, "Key::AltR"),
-            Key::Delete => write!(f, "Key::Delete"),
-            _ => write!(f, "0x{:02x}", *self as i32),
-        }
+bitflags! {
+    /// Defines the modifiers of virtual keycodes
+    pub struct Shortcut: i32 {
+        const None = 0;
+        const Shift = 0x0001_0000;
+        const CapsLock = 0x0002_0000;
+        const Ctrl = 0x0004_0000;
+        const Alt = 0x0008_0000;
     }
 }
 
-/// Defines the modifiers of virtual keycodes
-#[repr(i32)]
-#[derive(Copy, Clone, PartialEq)]
-pub enum Shortcut {
-    None = 0,
-    Shift = 0x0001_0000,
-    CapsLock = 0x0002_0000,
-    Ctrl = 0x0004_0000,
-    Alt = 0x0008_0000,
-}
 
 impl Shortcut {
     /// Create a shortcut from a char
@@ -474,53 +369,20 @@ impl Shortcut {
     }
 }
 
-#[allow(unreachable_patterns)]
-impl std::fmt::Debug for Shortcut {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use Shortcut::*;
-        match *self {
-            None => write!(f, "Shortcut::None"),
-            Shift => write!(f, "Shortcut::Shift"),
-            CapsLock => write!(f, "Shortcut::CapsLock"),
-            Ctrl => write!(f, "Shortcut::Ctrl"),
-            Alt => write!(f, "Shortcut::Alt"),
-            _ => write!(f, "0x{:08x}", *self as i32),
-        }
+bitflags! {
+    /// Defines the types of triggers for widget callback functions
+    pub struct CallbackTrigger: i32 {
+        const Never = 0;
+        const Changed = 1;
+        const NotChanged = 2;
+        const Release = 4;
+        const ReleaseAlways = 6;
+        const EnterKey = 8;
+        const EnterKeyAlways = 10;
+        const EnterKeyChanged = 11;
     }
 }
 
-/// Defines the types of triggers for widget callback functions
-#[repr(i32)]
-#[derive(Copy, Clone, PartialEq)]
-pub enum CallbackTrigger {
-    Never = 0,
-    Changed = 1,
-    NotChanged = 2,
-    Release = 4,
-    ReleaseAlways = 6,
-    EnterKey = 8,
-    EnterKeyAlways = 10,
-    EnterKeyChanged = 11,
-}
-
-
-#[allow(unreachable_patterns)]
-impl std::fmt::Debug for CallbackTrigger {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use CallbackTrigger::*;
-        match *self {
-            Never => write!(f, "CallbackTrigger::Never"),
-            Changed => write!(f, "CallbackTrigger::Changed"),
-            NotChanged => write!(f, "CallbackTrigger::NotChanged"),
-            Release => write!(f, "CallbackTrigger::Release"),
-            ReleaseAlways => write!(f, "CallbackTrigger::ReleaseAlways"),
-            EnterKey => write!(f, "CallbackTrigger::EnterKey"),
-            EnterKeyAlways => write!(f, "CallbackTrigger::EnterKeyAlways"),
-            EnterKeyChanged => write!(f, "CallbackTrigger::EnterKeyChanged"),
-            _ => write!(f, "0x{:02x}", *self as i32),
-        }
-    }
-}
 
 /// Defines the text cursor styles supported by fltk
 #[repr(i32)]
@@ -561,44 +423,21 @@ pub enum Cursor {
     None = 255,
 }
 
-/// Defines Fl_Mode types
-#[repr(i32)]
-#[derive(Copy, Clone, PartialEq)]
-pub enum Mode {
-    Rgb = 0,
-    Index = 1,
-    Double = 2,
-    Accum = 4,
-    Alpha = 8,
-    Depth = 16,
-    Stencil = 32,
-    Rgb8 = 64,
-    MultiSample = 128,
-    Stereo = 256,
-    FakeSingle = 512, // Fake single buffered windows using double-buffer
-    Opengl3 = 1024,
-}
-
-
-#[allow(unreachable_patterns)]
-impl std::fmt::Debug for Mode {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use Mode::*;
-        match *self {
-            Rgb => write!(f, "Mode::Rgb"),
-            Index => write!(f, "Mode::Index"),
-            Double => write!(f, "Mode::Double"),
-            Accum => write!(f, "Mode::Accum"),
-            Alpha => write!(f, "Mode::Alpha"),
-            Depth => write!(f, "Mode::Depth"),
-            Stencil => write!(f, "Mode::Stencil"),
-            Rgb8 => write!(f, "Mode::Rgb8"),
-            MultiSample => write!(f, "Mode::MultiSample"),
-            Stereo => write!(f, "Mode::Stereo"),
-            FakeSingle => write!(f, "Mode::FakeSingle"),
-            Opengl3 => write!(f, "Mode::Opengl3"),
-            _ => write!(f, "0x{:04x}", *self as i32),
-        }
+bitflags! {
+    /// Defines Fl_Mode types
+    pub struct Mode: i32 {
+        const Rgb = 0;
+        const Index = 1;
+        const Double = 2;
+        const Accum = 4;
+        const Alpha = 8;
+        const Depth = 16;
+        const Stencil = 32;
+        const Rgb8 = 64;
+        const MultiSample = 128;
+        const Stereo = 256;
+        const FakeSingle = 512; // Fake single buffered windows using double-buffer
+        const Opengl3 = 1024;
     }
 }
 
@@ -610,69 +449,20 @@ pub trait WidgetType {
 impl std::ops::BitOr<char> for Shortcut {
     type Output = Shortcut;
     fn bitor(self, other: char) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | other as i32) }
+        unsafe { std::mem::transmute(self.bits as i32 | other as i32) }
     }
 }
 
 impl std::ops::BitOr<Key> for Shortcut {
     type Output = Shortcut;
     fn bitor(self, other: Key) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | other as i32) }
-    }
-}
-
-impl std::ops::BitOr<Shortcut> for Shortcut {
-    type Output = Shortcut;
-    fn bitor(self, other: Shortcut) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | other as i32) }
-    }
-}
-
-impl std::ops::BitOr<CallbackTrigger> for CallbackTrigger {
-    type Output = CallbackTrigger;
-    fn bitor(self, rhs: CallbackTrigger) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | rhs as i32) }
-    }
-}
-
-impl std::ops::BitOr<Align> for Align {
-    type Output = Align;
-    fn bitor(self, rhs: Align) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | rhs as i32) }
+        unsafe { std::mem::transmute(self.bits as i32 | other.bits() as i32) }
     }
 }
 
 impl std::ops::BitOr<i32> for Align {
     type Output = Align;
     fn bitor(self, rhs: i32) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | rhs as i32) }
-    }
-}
-
-impl std::ops::BitOr<Font> for Font {
-    type Output = Font;
-    fn bitor(self, rhs: Font) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | rhs as i32) }
-    }
-}
-
-impl std::ops::BitOr<Event> for Event {
-    type Output = Event;
-    fn bitor(self, rhs: Event) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | rhs as i32) }
-    }
-}
-
-impl std::ops::BitOr<Key> for Key {
-    type Output = Key;
-    fn bitor(self, rhs: Key) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | rhs as i32) }
-    }
-}
-
-impl std::ops::BitOr<Mode> for Mode {
-    type Output = Mode;
-    fn bitor(self, rhs: Mode) -> Self::Output {
-        unsafe { std::mem::transmute(self as i32 | rhs as i32) }
+        unsafe { std::mem::transmute(self.bits | rhs as i32) }
     }
 }

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -158,43 +158,45 @@ impl Font {
     }
 }
 
-/// Defines colors used by FLTK
-/// Colors are stored as RGBI values, the last being the index for FLTK colors in this enum. 
-/// Colors in this enum don't have an RGB stored. However, custom colors have an RGB, and don't have an index.
-/// The RGBI can be acquired by casting the color to u32 and formatting it to ```0x{08x}```.
-/// The last 2 digits are the hexadecimal representation of the color in this enum.
-/// For example, Color::White, has a hex of 0x000000ff, ff being the 255 value of this enum. 
-/// A custom color like Color::from_u32(0x646464), will have an representation as 0x64646400,
-/// of which the final 00 indicates that it is not stored in this enum.
-#[repr(u32)]
-#[derive(Copy, Clone, PartialEq)]
-pub enum Color {
-    ForeGround = 0,
-    BackGround = 7,
-    Inactive = 8,
-    Selection = 15,
-    Gray0 = 32,
-    Dark3 = 39,
-    Dark2 = 45,
-    Dark1 = 47,
-    FrameDefault = 49,
-    Light1 = 50,
-    Light2 = 52,
-    Light3 = 54,
-    Black = 56,
-    Red = 88,
-    Green = 63,
-    Yellow = 95,
-    Blue = 216,
-    Magenta = 248,
-    Cyan = 223,
-    DarkRed = 72,
-    DarkGreen = 60,
-    DarkYellow = 76,
-    DarkBlue = 136,
-    DarkMagenta = 152,
-    DarkCyan = 140,
-    White = 255,
+bitflags! {
+    /// Defines colors used by FLTK
+    /// Colors are stored as RGBI values, the last being the index for FLTK colors in this enum. 
+    /// Colors in this enum don't have an RGB stored. However, custom colors have an RGB, and don't have an index.
+    /// The RGBI can be acquired by casting the color to u32 and formatting it to ```0x{08x}```.
+    /// The last 2 digits are the hexadecimal representation of the color in this enum.
+    /// For example, Color::White, has a hex of 0x000000ff, ff being the 255 value of this enum. 
+    /// A custom color like Color::from_u32(0x646464), will have an representation as 0x64646400,
+    /// of which the final 00 indicates that it is not stored in this enum.
+    /// For convenience, the fmt::Display trait is implemented so that the name of the Color is shown
+    /// when there is one, otherwise the RGB value is given.
+    pub struct Color: u32 {
+        const ForeGround = 0;
+        const BackGround = 7;
+        const Inactive = 8;
+        const Selection = 15;
+        const Gray0 = 32;
+        const Dark3 = 39;
+        const Dark2 = 45;
+        const Dark1 = 47;
+        const FrameDefault = 49;
+        const Light1 = 50;
+        const Light2 = 52;
+        const Light3 = 54;
+        const Black = 56;
+        const Red = 88;
+        const Green = 63;
+        const Yellow = 95;
+        const Blue = 216;
+        const Magenta = 248;
+        const Cyan = 223;
+        const DarkRed = 72;
+        const DarkGreen = 60;
+        const DarkYellow = 76;
+        const DarkBlue = 136;
+        const DarkMagenta = 152;
+        const DarkCyan = 140;
+        const White = 255;
+    }
 }
 
 impl Color {
@@ -211,37 +213,39 @@ impl Color {
 }
 
 #[allow(unreachable_patterns)]
-impl std::fmt::Debug for Color {
+impl std::fmt::Display for Color {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use Color::*;
         match *self {
-            ForeGround => write!(f, "Color::ForeGround"),
-            BackGround => write!(f, "Color::BackGround"),
-            Inactive => write!(f, "Color::Inactive"),
-            Selection => write!(f, "Color::Selection"),
-            Gray0 => write!(f, "Color::Gray0"),
-            Dark3 => write!(f, "Color::Dark3"),
-            Dark2 => write!(f, "Color::Dark2"),
-            Dark1 => write!(f, "Color::Dark1"),
-            FrameDefault => write!(f, "Color::FrameDefault"),
-            Light1 => write!(f, "Color::Light1"),
-            Light2 => write!(f, "Color::Light2"),
-            Light3 => write!(f, "Color::Light3"),
-            Black => write!(f, "Color::Black"),
-            Red => write!(f, "Color::Red"),
-            Green => write!(f, "Color::Green"),
-            Yellow => write!(f, "Color::Yellow"),
-            Blue => write!(f, "Color::Blue"),
-            Magenta => write!(f, "Color::Magenta"),
-            Cyan => write!(f, "Color::Cyan"),
-            DarkRed => write!(f, "Color::DarkRed"),
-            DarkGreen => write!(f, "Color::DarkGreen"),
-            DarkYellow => write!(f, "Color::DarkYellow"),
-            DarkBlue => write!(f, "Color::DarkBlue"),
-            DarkMagenta => write!(f, "Color::DarkMagenta"),
-            DarkCyan => write!(f, "Color::DarkCyan"),
-            White => write!(f, "Color::White"),
-            _ => write!(f, "{:06x}", *self as u32),
+            Color::ForeGround => write!(f, "ForeGround"),
+            Color::BackGround => write!(f, "BackGround"),
+            Color::Inactive => write!(f, "Inactive"),
+            Color::Selection => write!(f, "Selection"),
+            Color::Gray0 => write!(f, "Gray0"),
+            Color::Dark3 => write!(f, "Dark3"),
+            Color::Dark2 => write!(f, "Dark2"),
+            Color::Dark1 => write!(f, "Dark1"),
+            Color::FrameDefault => write!(f, "FrameDefault"),
+            Color::Light1 => write!(f, "Light1"),
+            Color::Light2 => write!(f, "Light2"),
+            Color::Light3 => write!(f, "Light3"),
+            Color::Black => write!(f, "Black"),
+            Color::Red => write!(f, "Red"),
+            Color::Green => write!(f, "Green"),
+            Color::Yellow => write!(f, "Yellow"),
+            Color::Blue => write!(f, "Blue"),
+            Color::Magenta => write!(f, "Magenta"),
+            Color::Cyan => write!(f, "Cyan"),
+            Color::DarkRed => write!(f, "DarkRed"),
+            Color::DarkGreen => write!(f, "DarkGreen"),
+            Color::DarkYellow => write!(f, "DarkYellow"),
+            Color::DarkBlue => write!(f, "DarkBlue"),
+            Color::DarkMagenta => write!(f, "DarkMagenta"),
+            Color::DarkCyan => write!(f, "DarkCyan"),
+            Color::White => write!(f, "White"),
+            _ => { 
+                let temp = format!("{:08x}", self.bits);
+                write!(f, "0x{}", &temp[0..6])
+            },
         }
     }
 }

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -173,7 +173,7 @@ impl Font {
     /// Returns a font by index, can be queried via the app::get_font_names()
     pub fn by_index(idx: usize) -> Font {
         unsafe {
-            if idx < FONTS.len() {
+            if idx < (*FONTS.lock().unwrap()).len() {
                 std::mem::transmute(idx as i32)
             } else {
                 Font::Helvetica

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -198,7 +198,7 @@ impl Tabs {
     /// Sets the tab label alignment
     pub fn set_tab_align(&mut self, a: Align) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Tabs_set_tab_align(self._inner, a as i32) }
+        unsafe { Fl_Tabs_set_tab_align(self._inner, a.bits() as i32) }
     }
 
     /// Gets the tab label alignment.

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -222,3 +222,6 @@ pub use prelude::*;
 
 #[macro_use]
 extern crate fltk_derive;
+
+#[macro_use]
+extern crate lazy_static;

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -191,6 +191,8 @@
 //!
 //! please check the [FAQ](https://github.com/MoAlyousef/fltk-rs/blob/master/FAQ.md) page for frequently asked questions, encountered issues, guides on deployment, and contribution.
 
+#![allow(non_upper_case_globals)]
+
 pub mod app;
 pub mod browser;
 pub mod button;
@@ -225,3 +227,6 @@ extern crate fltk_derive;
 
 #[macro_use]
 extern crate lazy_static;
+
+#[macro_use]
+extern crate bitflags;

--- a/fltk/src/menu.rs
+++ b/fltk/src/menu.rs
@@ -149,7 +149,7 @@ impl MenuItem {
     /// Sets the label color of the menu item
     pub fn set_label_color(&mut self, color: Color) {
         assert!(!self.was_deleted() && !self._inner.is_null());
-        unsafe { Fl_Menu_Item_set_label_color(self._inner, color as u32) }
+        unsafe { Fl_Menu_Item_set_label_color(self._inner, color.bits() as u32) }
     }
 
     /// Returns the label font of the menu item

--- a/fltk/src/menu.rs
+++ b/fltk/src/menu.rs
@@ -161,7 +161,7 @@ impl MenuItem {
     /// Sets the label font of the menu item
     pub fn set_label_font(&mut self, font: Font) {
         assert!(!self.was_deleted() && !self._inner.is_null());
-        unsafe { Fl_Menu_Item_set_label_font(self._inner, font as i32) }
+        unsafe { Fl_Menu_Item_set_label_font(self._inner, font.bits() as i32) }
     }
 
     /// Returns the label size of the menu item

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -133,7 +133,7 @@ impl Spinner {
     /// Sets the text's color
     pub fn set_text_color(&mut self, color: Color) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Spinner_set_text_color(self._inner, color as u32) }
+        unsafe { Fl_Spinner_set_text_color(self._inner, color.bits() as u32) }
     }
 }
 
@@ -162,7 +162,7 @@ impl Chart {
     pub fn add(&mut self, val: f64, txt: &str, col: Color) {
         assert!(!self.was_deleted());
         let txt = CString::safe_new(txt);
-        unsafe { Fl_Chart_add(self._inner, val, txt.as_ptr(), col as u32) }
+        unsafe { Fl_Chart_add(self._inner, val, txt.as_ptr(), col.bits() as u32) }
     }
 
     /// Inserts an entry at an index
@@ -173,7 +173,7 @@ impl Chart {
         );
         assert!(!self.was_deleted());
         let txt = CString::safe_new(txt);
-        unsafe { Fl_Chart_insert(self._inner, idx as i32, val, txt.as_ptr(), col as u32) }
+        unsafe { Fl_Chart_insert(self._inner, idx as i32, val, txt.as_ptr(), col.bits() as u32) }
     }
 
     /// Replaces an entry at an index
@@ -184,7 +184,7 @@ impl Chart {
         );
         assert!(!self.was_deleted());
         let txt = CString::safe_new(txt);
-        unsafe { Fl_Chart_replace(self._inner, idx as i32, val, txt.as_ptr(), col as u32) }
+        unsafe { Fl_Chart_replace(self._inner, idx as i32, val, txt.as_ptr(), col.bits() as u32) }
     }
 
     /// Sets the bounds of the chart
@@ -266,7 +266,7 @@ impl Chart {
     /// Sets the text's color
     pub fn set_text_color(&mut self, color: Color) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Chart_set_text_color(self._inner, color as u32) }
+        unsafe { Fl_Chart_set_text_color(self._inner, color.bits() as u32) }
     }
 
     /// Returns wheter the chart is autosizable
@@ -453,7 +453,7 @@ impl Tooltip {
 
     /// Sets the tooltip's color
     pub fn set_color(c: Color) {
-        unsafe { Fl_Tooltip_set_color(c as u32) }
+        unsafe { Fl_Tooltip_set_color(c.bits() as u32) }
     }
 
     /// Gets the tooltip's text color
@@ -463,7 +463,7 @@ impl Tooltip {
 
     /// Sets the tooltip's text color
     pub fn set_text_color(c: Color) {
-        unsafe { Fl_Tooltip_set_text_color(c as u32) }
+        unsafe { Fl_Tooltip_set_text_color(c.bits() as u32) }
     }
 
     /// Gets the margin width

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -105,7 +105,7 @@ impl Spinner {
     /// Sets the text font
     pub fn set_text_font(&mut self, f: Font) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Spinner_set_text_font(self._inner, f as i32) }
+        unsafe { Fl_Spinner_set_text_font(self._inner, f.bits() as i32) }
     }
 
     /// Gets the text size
@@ -238,7 +238,7 @@ impl Chart {
     /// Sets the text font
     pub fn set_text_font(&mut self, f: Font) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Chart_set_text_font(self._inner, f as i32) }
+        unsafe { Fl_Chart_set_text_font(self._inner, f.bits() as i32) }
     }
 
     /// Gets the text size
@@ -429,7 +429,7 @@ impl Tooltip {
 
     /// Sets the tooltip's font
     pub fn set_font(font: Font) {
-        unsafe { Fl_Tooltip_set_font(font as i32) }
+        unsafe { Fl_Tooltip_set_font(font.bits() as i32) }
     }
 
     /// Gets the tooltip's font size

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -696,7 +696,7 @@ impl TextEditor {
         assert!(!self.was_deleted());
         assert!(self.buffer().is_some());
         unsafe {
-            Fl_Text_Editor_kf_default(c as i32, self._inner);
+            Fl_Text_Editor_kf_default(c.bits() as i32, self._inner);
         }
     }
 
@@ -705,7 +705,7 @@ impl TextEditor {
         assert!(!self.was_deleted());
         assert!(self.buffer().is_some());
         unsafe {
-            Fl_Text_Editor_kf_ignore(c as i32, self._inner);
+            Fl_Text_Editor_kf_ignore(c.bits() as i32, self._inner);
         }
     }
 
@@ -732,7 +732,7 @@ impl TextEditor {
         assert!(!self.was_deleted());
         assert!(self.buffer().is_some());
         unsafe {
-            Fl_Text_Editor_kf_move(c as i32, self._inner);
+            Fl_Text_Editor_kf_move(c.bits() as i32, self._inner);
         }
     }
 
@@ -741,7 +741,7 @@ impl TextEditor {
         assert!(!self.was_deleted());
         assert!(self.buffer().is_some());
         unsafe {
-            Fl_Text_Editor_kf_shift_move(c as i32, self._inner);
+            Fl_Text_Editor_kf_shift_move(c.bits() as i32, self._inner);
         }
     }
 
@@ -750,7 +750,7 @@ impl TextEditor {
         assert!(!self.was_deleted());
         assert!(self.buffer().is_some());
         unsafe {
-            Fl_Text_Editor_kf_ctrl_move(c as i32, self._inner);
+            Fl_Text_Editor_kf_ctrl_move(c.bits() as i32, self._inner);
         }
     }
 
@@ -759,7 +759,7 @@ impl TextEditor {
         assert!(!self.was_deleted());
         assert!(self.buffer().is_some());
         unsafe {
-            Fl_Text_Editor_kf_c_s_move(c as i32, self._inner);
+            Fl_Text_Editor_kf_c_s_move(c.bits() as i32, self._inner);
         }
     }
 
@@ -768,7 +768,7 @@ impl TextEditor {
         assert!(!self.was_deleted());
         assert!(self.buffer().is_some());
         unsafe {
-            Fl_Text_Editor_kf_meta_move(c as i32, self._inner);
+            Fl_Text_Editor_kf_meta_move(c.bits() as i32, self._inner);
         }
     }
 
@@ -777,7 +777,7 @@ impl TextEditor {
         assert!(!self.was_deleted());
         assert!(self.buffer().is_some());
         unsafe {
-            Fl_Text_Editor_kf_m_s_move(c as i32, self._inner);
+            Fl_Text_Editor_kf_m_s_move(c.bits() as i32, self._inner);
         }
     }
 

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -660,7 +660,7 @@ impl Tree {
     /// Sets the items' foreground color
     pub fn set_item_label_fg_color(&mut self, val: Color) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Tree_set_item_labelfgcolor(self._inner, val as u32) }
+        unsafe { Fl_Tree_set_item_labelfgcolor(self._inner, val.bits() as u32) }
     }
 
     /// Gets the items' background color
@@ -672,7 +672,7 @@ impl Tree {
     /// Sets the items' foreground color
     pub fn set_item_label_bg_color(&mut self, val: Color) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Tree_set_item_labelbgcolor(self._inner, val as u32) }
+        unsafe { Fl_Tree_set_item_labelbgcolor(self._inner, val.bits() as u32) }
     }
 
     /// Gets the items' connector color
@@ -684,7 +684,7 @@ impl Tree {
     /// Sets the items' foreground color
     pub fn set_connector_color(&mut self, val: Color) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Tree_set_connectorcolor(self._inner, val as u32) }
+        unsafe { Fl_Tree_set_connectorcolor(self._inner, val.bits() as u32) }
     }
 
     /// Gets the left margin
@@ -1325,7 +1325,7 @@ impl TreeItem {
     /// Sets the label's foreground color
     pub fn set_label_fg_color(&mut self, val: Color) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Tree_Item_set_labelfgcolor(self._inner, val as u32) }
+        unsafe { Fl_Tree_Item_set_labelfgcolor(self._inner, val.bits() as u32) }
     }
 
     /// Gets the label's foreground color
@@ -1337,7 +1337,7 @@ impl TreeItem {
     /// Sets the label's color
     pub fn set_label_color(&mut self, val: Color) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Tree_Item_set_labelcolor(self._inner, val as u32) }
+        unsafe { Fl_Tree_Item_set_labelcolor(self._inner, val.bits() as u32) }
     }
 
     /// Gets the label's color
@@ -1349,7 +1349,7 @@ impl TreeItem {
     /// Sets the label's background color
     pub fn set_label_bg_color(&mut self, val: Color) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Tree_Item_set_labelbgcolor(self._inner, val as u32) }
+        unsafe { Fl_Tree_Item_set_labelbgcolor(self._inner, val.bits() as u32) }
     }
 
     /// Gets the label's foreground color

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -311,7 +311,7 @@ impl Tree {
             TreeItem::from_raw(Fl_Tree_next_visible_item(
                 self._inner,
                 start._inner,
-                direction_key as i32,
+                direction_key.bits() as i32,
             ))
         }
     }
@@ -343,7 +343,7 @@ impl Tree {
             TreeItem::from_raw(Fl_Tree_next_item(
                 self._inner,
                 item._inner,
-                direction_key as i32,
+                direction_key.bits() as i32,
                 visible as i32,
             ))
         }
@@ -359,7 +359,7 @@ impl Tree {
             TreeItem::from_raw(Fl_Tree_next_selected_item(
                 self._inner,
                 item._inner,
-                direction_key as i32,
+                direction_key.bits() as i32,
             ))
         }
     }
@@ -562,7 +562,7 @@ impl Tree {
                 self._inner,
                 from._inner,
                 to._inner,
-                direction_key as i32,
+                direction_key.bits() as i32,
                 val as i32,
                 visible as i32,
             ) {
@@ -632,7 +632,7 @@ impl Tree {
     /// Sets the items' label font
     pub fn set_item_label_font(&mut self, val: Font) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Tree_set_item_labelfont(self._inner, val as i32) }
+        unsafe { Fl_Tree_set_item_labelfont(self._inner, val.bits() as i32) }
     }
 
     /// Gets the items' label size
@@ -1297,7 +1297,7 @@ impl TreeItem {
     /// Sets the label's font
     pub fn set_label_font(&mut self, val: Font) {
         assert!(!self.was_deleted());
-        unsafe { Fl_Tree_Item_set_labelfont(self._inner, val as i32) }
+        unsafe { Fl_Tree_Item_set_labelfont(self._inner, val.bits() as i32) }
     }
 
     /// Gets the label's font


### PR DESCRIPTION
- [BREAKING] Remove enums::Color::to_rgb and to_u32.
- [BREAKING] WidgetExt::trigger returns a CallbackTrigger instead of an int.
- Add custom Display implementation for Color.
- Use lazy_static for globals.
- Use bitflags for several enum types.
- Add utils::rgb2hex and utils::hex2rgb.
- Add draw::set_draw_rgb_color() and set_draw_hex_color().
- Relax app::Message requirements to only be Send + Sync.
- Add app::set_font(Font) to set global app font.
- Add app::set_color(Color) to set the global app's background color.
- Add app::visible_focus and set_visible_focus.
- Fix WidgetExt::center_of() to account for special positioning within windows.
- WidgetExt::as_window and as_group only require immutable ref to self.
- Default Window to a DoubleWindow instead of single window for better performance.