### PR TITLE
0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## [0.12.10] - 2021-01-07
+
+## [0.13.0] - 2021-01-07
 ### Changes
+- [BREAKING] Remove deprecated calls app::set_color and calls to scrollbar_width (should be replaced by scrollbar_size)
 - Add proper Default impl for use with fl2rust.
 - Add Color::by_index(u8).
 - Add WindowExt::hotspot().
@@ -10,13 +12,10 @@
 - Add HelpView and InputChoice widgets in the misc module.
 - Add CheckBrowser in the browser module.
 - Add app::get_system_colors().
-- Deprecate calls to scrollbar_width, use scrollbar_size instead.
-
 
 ## [0.12.8] - 2021-01-06
 ### Changes
 - Add WindowExt::size_range which sets min/max width/height.
-
 
 ## [0.12.7] - 2021-01-05
 ### Changes

--- a/FAQ.md
+++ b/FAQ.md
@@ -11,7 +11,7 @@ The first tutorial uses the fltk-bundled feature flag, which is only supported f
 If you're not running one of the aforementioned platforms, you'll have to remove the fltk-bundled feature flag in your Cargo.toml file:
 ```toml
 [dependencies]
-fltk = "^0.12"
+fltk = "^0.13"
 ```
 Furthermore, the fltk-bundled flag assumes you have curl and tar installed (for Windows, they're available in the Native Tools Command Prompt).
 
@@ -24,7 +24,7 @@ If you're building for the GNU toolchain, make sure that Make is also installed,
 If the linking fails because of this issue: https://github.com/rust-lang/rust/issues/47048 with older toolchains, it should work by using the fltk-shared feature (an issue with older compilers). Which would also generate a dynamic library which would need to be deployed with your application.
 ```toml
 [dependencies]
-fltk = { version = "^0.12", features = ["fltk-shared"] }
+fltk = { version = "^0.13", features = ["fltk-shared"] }
 ```
 
 ### Build fails on Arch linux because of pango or cairo?

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Just add the following to your project's Cargo.toml file:
 
 ```toml
 [dependencies]
-fltk = "^0.12"
+fltk = "^0.13"
 ```
 
 The library is automatically built and statically linked to your binary.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,3 @@
 # Roadmap
 
-## Version 0.13.0
-- Remove deprecated functions.
 

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.12.10"
+version = "0.13.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.12.10"
+version = "0.13.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.12.10"
+version = "0.13.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=0.12.10" }
-fltk-derive = { path = "../fltk-derive", version = "=0.12.10" }
+fltk-sys = { path = "../fltk-sys", version = "=0.13.0" }
+fltk-derive = { path = "../fltk-derive", version = "=0.13.0" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -446,15 +446,6 @@ pub fn set_frame_type(new_frame: FrameType) {
     }
 }
 
-/// Sets the app's default background color
-#[deprecated(
-    since = "0.12.4",
-    note = "Please use the background function instead"
-)]
-pub fn set_color(r: u8, g: u8, b: u8) {
-    unsafe { Fl_set_color(Color::FrameDefault.bits() as u32, r, g, b) }
-}
-
 /// Set the app's font
 pub fn set_font(new_font: Font) {
     unsafe {

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! fltk = "^0.12"
+//! fltk = "^0.13"
 //! ```
 //! The library is automatically built and statically linked to your binary.
 //!

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -681,20 +681,12 @@ impl HelpView {
     }
 
     /// Find a string, returns the index
-    pub fn find(&self, s: &str, start_from: u32) -> Option<u32> {
+    pub fn find(&self, s: &str, start_from: usize) -> Option<usize> {
         assert!(!self.was_deleted());
-        debug_assert!(
-            start_from <= std::isize::MAX as u32,
-            "u32 entries have to be < std::isize::MAX for compatibility!"
-        );
-        unsafe {
-            let s = CString::safe_new(s);
-            let idx = Fl_Help_View_find(self._inner, s.as_ptr(), start_from as i32);
-            println!("{}", idx);
-            match idx {
-                -1 => None,
-                _ => Some(idx as u32),
-            }
+        if let Some(v) = self.value() {
+            v[start_from..].find(s).map(|idx| start_from + idx)
+        } else {
+            None
         }
     }
 

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -702,12 +702,6 @@ pub unsafe trait DisplayExt: WidgetExt {
     fn set_cursor_style(&mut self, style: TextCursor);
     /// Sets the cursor color
     fn set_cursor_color(&mut self, color: Color);
-    /// Sets the scrollbar width
-    #[deprecated(
-        since = "0.12.9",
-        note = "Please use the size function instead"
-    )]
-    fn set_scrollbar_width(&mut self, width: i32);
     /// Sets the scrollbar size in pixels
     fn set_scrollbar_size(&mut self, size: u32);
     /// Sets the scrollbar alignment
@@ -716,12 +710,6 @@ pub unsafe trait DisplayExt: WidgetExt {
     fn cursor_style(&self) -> TextCursor;
     /// Returns the cursor color
     fn cursor_color(&self) -> Color;
-    /// Returns the scrollback width
-    #[deprecated(
-        since = "0.12.9",
-        note = "Please use the size function instead"
-    )]
-    fn scrollbar_width(&self) -> u32;
     /// Returns the scrollbar size in pixels
     fn scrollbar_size(&self) -> u32;
     /// Returns the scrollbar alignment
@@ -877,18 +865,6 @@ pub unsafe trait BrowserExt: WidgetExt {
     fn scrollbar_size(&self) -> u32;
     /// Sets the scrollbar size
     fn set_scrollbar_size(&mut self, new_size: u32);
-    /// Gets the scrollbar width
-    #[deprecated(
-        since = "0.12.9",
-        note = "Please use the size function instead"
-    )]
-    fn scrollbar_width(&self) -> i32;
-    /// Sets the scrollbar width
-    #[deprecated(
-        since = "0.12.9",
-        note = "Please use the size function instead"
-    )]
-    fn set_scrollbar_width(&mut self, width: i32);
     /// Sorts the items of the browser
     fn sort(&mut self);
     /// Returns the vertical scrollbar


### PR DESCRIPTION
- [BREAKING] Remove deprecated calls app::set_color and calls to scrollbar_width (should be replaced by scrollbar_size)
- Add proper Default impl for use with fl2rust.
- Add Color::by_index(u8).
- Add WindowExt::hotspot().
- Add Group::current().
- Add ButtonExt and MenuExt down_box().
- Add HelpView and InputChoice widgets in the misc module.
- Add CheckBrowser in the browser module.
- Add app::get_system_colors().