### PR TITLE
0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [0.13.0] - 2021-01-07
+## [0.13.1] - 2021-01-07
 ### Changes
 - [BREAKING] Remove deprecated calls app::set_color and calls to scrollbar_width (should be replaced by scrollbar_size)
 - Add proper Default impl for use with fl2rust.

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/browser.rs
+++ b/fltk-derive/src/browser.rs
@@ -107,14 +107,6 @@ pub fn impl_browser_trait(ast: &DeriveInput) -> TokenStream {
         format!("{}_{}", name_str, "set_scrollbar_size").as_str(),
         name.span(),
     );
-    let scrollbar_width = Ident::new(
-        format!("{}_{}", name_str, "scrollbar_width").as_str(),
-        name.span(),
-    );
-    let set_scrollbar_width = Ident::new(
-        format!("{}_{}", name_str, "set_scrollbar_width").as_str(),
-        name.span(),
-    );
     let sort = Ident::new(format!("{}_{}", name_str, "sort").as_str(), name.span());
     let scrollbar = Ident::new(
         format!("{}_{}", name_str, "scrollbar").as_str(),
@@ -446,20 +438,6 @@ pub fn impl_browser_trait(ast: &DeriveInput) -> TokenStream {
                 debug_assert!(new_size <= std::isize::MAX as u32, "u32 entries have to be < std::isize::MAX for compatibility!");
                 unsafe {
                     #set_scrollbar_size(self._inner, new_size as i32)
-                }
-            }
-
-            fn scrollbar_width(&self) -> i32 {
-                assert!(!self.was_deleted());
-                unsafe {
-                    #scrollbar_width(self._inner)
-                }
-            }
-
-            fn set_scrollbar_width(&mut self, width: i32) {
-                assert!(!self.was_deleted());
-                unsafe {
-                    #set_scrollbar_width(self._inner, width)
                 }
             }
 

--- a/fltk-derive/src/display.rs
+++ b/fltk-derive/src/display.rs
@@ -102,10 +102,6 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
         format!("{}_{}", name_str, "set_scrollbar_align").as_str(),
         name.span(),
     );
-    let set_scrollbar_width = Ident::new(
-        format!("{}_{}", name_str, "set_scrollbar_width").as_str(),
-        name.span(),
-    );
     let cursor_style = Ident::new(
         format!("{}_{}", name_str, "cursor_style").as_str(),
         name.span(),
@@ -120,10 +116,6 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
     );
     let scrollbar_align = Ident::new(
         format!("{}_{}", name_str, "scrollbar_align").as_str(),
-        name.span(),
-    );
-    let scrollbar_width = Ident::new(
-        format!("{}_{}", name_str, "scrollbar_width").as_str(),
         name.span(),
     );
     let line_start = Ident::new(
@@ -445,13 +437,6 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
                 }
             }
 
-            fn set_scrollbar_width(&mut self, width: i32){
-                unsafe {
-                    assert!(!self.was_deleted());
-                    #set_scrollbar_width(self._inner, width)
-                }
-            }
-
             fn set_scrollbar_size(&mut self, size: u32){
                 debug_assert!(size <= std::isize::MAX as u32, "u32 entries have to be < std::isize::MAX for compatibility!");
                 unsafe {
@@ -478,13 +463,6 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
                 unsafe {
                     assert!(!self.was_deleted());
                     mem::transmute(#cursor_color(self._inner))
-                }
-            }
-
-            fn scrollbar_width(&self) -> u32 {
-                unsafe {
-                    assert!(!self.was_deleted());
-                    #scrollbar_width(self._inner) as u32
                 }
             }
 

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=0.13.0" }
-fltk-derive = { path = "../fltk-derive", version = "=0.13.0" }
+fltk-sys = { path = "../fltk-sys", version = "=0.13.1" }
+fltk-derive = { path = "../fltk-derive", version = "=0.13.1" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 

--- a/fltk/examples/editor.rs
+++ b/fltk/examples/editor.rs
@@ -147,7 +147,7 @@ fn main() {
     // What shows when we attempt to print
     let mut printable = text::TextDisplay::default();
     printable.set_frame(FrameType::NoBox);
-    printable.set_scrollbar_width(0);
+    printable.set_scrollbar_size(0);
 
     let mut wind = window::Window::default()
         .with_size(800, 600)


### PR DESCRIPTION
- [BREAKING] Remove deprecated calls app::set_color and calls to scrollbar_width (should be replaced by scrollbar_size)
- Add proper Default impl for use with fl2rust.
- Add Color::by_index(u8).
- Add WindowExt::hotspot().
- Add Group::current().
- Add ButtonExt and MenuExt down_box().
- Add HelpView and InputChoice widgets in the misc module.
- Add CheckBrowser in the browser module.
- Add app::get_system_colors().