### PR TITLE
0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Changelog
 
-## [0.13.2] - Unreleased
-### Changes
-- FAQ: Add info on keeping the console window only for debug builds on Windows.Thanks @dheijl
 
-## [0.13.1] - 2021-01-07
+## [0.13.3] - 2021-01-10
 ### Changes
-- [BREAKING] Remove deprecated calls app::set_color and calls to scrollbar_width (should be replaced by scrollbar_size)
+- [BREAKING] Remove deprecated calls app::set_color and calls to scrollbar_width (should be replaced by scrollbar_size).
+- [BREAKING] Change Color::BackGround to BackGround2 to better reflect the color of input/output widgets.
+- FAQ: Add info on keeping the console window only for debug builds on Windows.Thanks @dheijl
 - Add proper Default impl for use with fl2rust.
 - Add Color::by_index(u8).
 - Add WindowExt::hotspot().
@@ -15,6 +14,8 @@
 - Add HelpView and InputChoice widgets in the misc module.
 - Add CheckBrowser in the browser module.
 - Add app::get_system_colors().
+- Update dependencies.
+- Add missing docs.
 
 ## [0.12.8] - 2021-01-06
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changes
 - [BREAKING] Remove deprecated calls app::set_color and calls to scrollbar_width (should be replaced by scrollbar_size).
 - [BREAKING] Change Color::BackGround to BackGround2 to better reflect the color of input/output widgets.
+- [BREAKING] TableRowSelectMode enum values were trimmed to remove Select prefix.
+- [BREAKING] DragType enum values were trimmed to remove Drag prefix.
 - FAQ: Add info on keeping the console window only for debug builds on Windows.Thanks @dheijl
 - Add proper Default impl for use with fl2rust.
 - Add Color::by_index(u8).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.13.2] - Unreleased
+### Changes
+- FAQ: Add info on keeping the console window only for debug builds on Windows.Thanks @dheijl
 
 ## [0.13.1] - 2021-01-07
 ### Changes

--- a/FAQ.md
+++ b/FAQ.md
@@ -53,7 +53,10 @@ You can use the "use-ninja" feature flag if you have ninja installed. Or you can
 Rust, by default, statically links your application. FLTK is built also for static linking. That means that the resulting executable can be directly deployed without the need to deploy other files along with it. If you want to create a WIN32 application, Mac OS Bundle or Linux AppImage, please check the question just below!
 
 ### Why do I get a console window whenever I start my GUI app?
-This is the default behavior of the toolchain, and is helpful for debugging purposes. It can be turned off easily by adding ```#![windows_subsystem = "windows"]``` at the beginning of your main.rs file if you're on windows. For Mac OS and Linux, this is done by a post-build process to create a Mac OS Bundle or Linux AppImage respectively.
+This is the default behavior of the toolchain, and is helpful for debugging purposes. It can be turned off easily by adding ```#![windows_subsystem = "windows"]``` at the beginning of your main.rs file if you're on windows. 
+If you would like to keep the console window on debug builds, but not on release builds, you can use ```#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]``` instead.
+
+For Mac OS and Linux, this is done by a post-build process to create a Mac OS Bundle or Linux AppImage respectively.
 
 See [cargo-bundle](https://github.com/burtonageo/cargo-bundle) for an automated tool for creating Mac OS app bundles. 
 

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.13.1"
+version = "0.13.3"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -14,5 +14,5 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-syn = "^1.0.57"
+syn = "^1.0.58"
 quote = "^1.0.8"

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.13.1"
+version = "0.13.3"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"
@@ -14,7 +14,7 @@ name = "fltk_sys"
 path = "src/lib.rs"
 
 [dependencies]
-libc = "0.2.81"
+libc = "0.2.82"
 
 [build-dependencies]
 cmake = { version = "^0.1.45", git = "https://github.com/moalyousef/cmake-rs" }

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.13.1"
+version = "0.13.3"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=0.13.1" }
-fltk-derive = { path = "../fltk-derive", version = "=0.13.1" }
+fltk-sys = { path = "../fltk-sys", version = "=0.13.3" }
+fltk-derive = { path = "../fltk-derive", version = "=0.13.3" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 

--- a/fltk/examples/help_view.rs
+++ b/fltk/examples/help_view.rs
@@ -5,6 +5,7 @@ fn main() {
     let mut win = window::Window::new(100, 100, 400, 300, "Help View");
     let mut h = misc::HelpView::new(10, 10, 380, 280, "");
     h.set_value("Hello <b><font color=red>again</font></b>");
+    println!("{:?}", h.find("again", 0));
     win.end();
     win.show();
     app.run().unwrap();

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -17,6 +17,7 @@ use std::{
     time,
 };
 
+/// Alias Widget ptr
 pub type WidgetPtr = *mut fltk_sys::widget::Fl_Widget;
 
 lazy_static! {
@@ -426,10 +427,12 @@ pub unsafe fn set_raw_callback<W>(
     fltk_sys::widget::Fl_Widget_set_callback(widget.as_widget_ptr(), cb, data);
 }
 
+/// Return whether visible focus is shown
 pub fn visible_focus() -> bool {
     unsafe { Fl_visible_focus() != 0 }
 }
 
+/// Show focus around widgets
 pub fn set_visible_focus(flag: bool) {
     unsafe { Fl_set_visible_focus(flag as i32) }
 }

--- a/fltk/src/browser.rs
+++ b/fltk/src/browser.rs
@@ -18,9 +18,13 @@ pub struct Browser {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum BrowserType {
+    /// Normal browser
     Normal = 0,
+    /// Enable select
     Select = 1,
+    /// Enable holding
     Hold = 2,
+    /// Multi selection
     Multi = 3,
 }
 
@@ -28,13 +32,21 @@ pub enum BrowserType {
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum BrowserScrollbar {
+    /// Never show bars
     None = 0,
+    /// Show vertical bar
     Horizontal = 1,
+    /// Show vertical bar
     Vertical = 2,
+    /// Show both horizontal and vertical bars
     Both = 3,
+    /// Always show bars
     AlwaysOn = 4,
+    /// Show horizontal bar always
     HorizontalAlways = 5,
+    /// Show vertical bar always
     VerticalAlways = 6,
+    /// Always show both horizontal and vertical bars
     BothAlways = 7,
 }
 
@@ -66,10 +78,13 @@ pub struct FileBrowser {
     _tracker: *mut fltk_sys::fl::Fl_Widget_Tracker,
 }
 
+/// File types for the FileBrowser
 #[repr(i32)]
 #[derive(Copy, Clone, Debug)]
 pub enum FileType {
+    /// Show files
     Files = 0,
+    /// Show dirs
     Dirs,
 }
 

--- a/fltk/src/button.rs
+++ b/fltk/src/button.rs
@@ -18,9 +18,13 @@ pub struct Button {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum ButtonType {
+    /// Normal button
     Normal = 0,
+    /// Toggle button
     Toggle = 1,
+    /// Radio button
     Radio = 102,
+    /// Hidden button
     Hidden = 3,
 }
 

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -19,27 +19,40 @@ pub type NativeFileChooser = FileDialog;
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum FileDialogType {
+    /// Browse file
     BrowseFile = 0,
+    /// Browse dir
     BrowseDir,
+    /// Browse multiple files
     BrowseMultiFile,
+    /// Browse multiple dirs
     BrowseMultiDir,
+    /// Browse save file
     BrowseSaveFile,
+    /// Browse save directory
     BrowseSaveDir,
 }
 
+/// Alias for NativeFileChooserType
 pub type NativeFileChooserType = FileDialogType;
 
 /// Defines the File dialog options, which can be set using the set_option() method.
 #[repr(i32)]
 #[derive(WidgetType, Copy, Clone, PartialEq)]
 pub enum FileDialogOptions {
+    /// No options
     NoOptions = 0,
+    /// Confirm on save as
     SaveAsConfirm = 1,
+    /// New folder option
     NewFolder = 2,
+    /// Enable preview
     Preview = 4,
+    /// Use extension filter
     UseFilterExt = 8,
 }
 
+/// Alias to NativeFileChooserOptions
 pub type NativeFileChooserOptions = FileDialogOptions;
 
 impl std::ops::BitOr<FileDialogOptions> for FileDialogOptions {
@@ -399,11 +412,17 @@ impl Drop for HelpDialog {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum BeepType {
+    /// Default beep
     Default = 0,
+    /// Message beep
     Message,
+    /// Error beep
     Error,
+    /// Question beep
     Question,
+    /// Password sound
     Password,
+    /// Notification sound
     Notification,
 }
 
@@ -420,9 +439,13 @@ pub struct FileChooser {
 bitflags! {
     /// The types of FileChooser
     pub struct FileChooserType: i32 {
+        /// Single file
         const Single = 0;
+        /// Multiple files
         const Multi = 1;
+        /// Allow creation of file/dir
         const Create = 2;
+        /// Directory
         const Directory = 4;
     }
 }

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -13,16 +13,27 @@ pub struct Coord<T: Copy>(pub T, pub T);
 #[repr(i32)]
 #[derive(WidgetType, Copy, Clone, PartialEq)]
 pub enum LineStyle {
+    /// Solid line
     Solid = 0,
+    /// Dash
     Dash,
+    /// Dot
     Dot,
+    /// Dash dot
     DashDot,
+    /// Dash dot dot
     DashDotDot,
+    /// Cap flat
     CapFlat = 100,
+    /// Cap round
     CapRound = 200,
+    /// Cap square
     CapSquare = 300,
+    /// Join miter
     JoinMiter = 1000,
+    /// Join round
     JoinRound = 2000,
+    /// Join bevel
     JoinBevel = 3000,
 }
 

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -453,8 +453,11 @@ bitflags! {
     }
 }
 
+/// A trait defined for all enums passable to the WidgetExt::set_type() method
 pub trait WidgetType {
+    /// Get the integral representation of the widget type
     fn to_int(self) -> i32;
+    /// Get the widget type from its integral representation
     fn from_i32(val: i32) -> Self;
 }
 

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -171,7 +171,7 @@ bitflags! {
     /// when there is one, otherwise the RGB value is given.
     pub struct Color: u32 {
         const ForeGround = 0;
-        const BackGround = 7;
+        const BackGround2 = 7;
         const Inactive = 8;
         const Selection = 15;
         const Gray0 = 32;
@@ -179,6 +179,7 @@ bitflags! {
         const Dark2 = 45;
         const Dark1 = 47;
         const FrameDefault = 49;
+        const BackGround = 49;
         const Light1 = 50;
         const Light2 = 52;
         const Light3 = 54;

--- a/fltk/src/group.rs
+++ b/fltk/src/group.rs
@@ -17,6 +17,7 @@ pub struct Group {
 }
 
 impl Group {
+    /// Get the current group
     pub fn current() -> Box<dyn GroupExt> {
         unsafe {
             let ptr = Fl_Group_current();
@@ -37,7 +38,9 @@ pub struct Pack {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum PackType {
+    /// Vertical layout pack
     Vertical = 0,
+    /// Horizontal layout pack
     Horizontal = 1,
 }
 
@@ -52,13 +55,21 @@ pub struct Scroll {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum ScrollType {
+    /// Never show bars
     None = 0,
+    /// Show vertical bar
     Horizontal = 1,
+    /// Show vertical bar
     Vertical = 2,
+    /// Show both horizontal and vertical bars
     Both = 3,
+    /// Always show bars
     AlwaysOn = 4,
+    /// Show horizontal bar always
     HorizontalAlways = 5,
+    /// Show vertical bar always
     VerticalAlways = 6,
+    /// Always show both horizontal and vertical bars
     BothAlways = 7,
 }
 

--- a/fltk/src/input.rs
+++ b/fltk/src/input.rs
@@ -18,13 +18,21 @@ pub struct Input {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum InputType {
+    /// Normal input
     Normal = 0,
+    /// Float input
     Float = 1,
+    /// Int input
     Int = 2,
+    /// Multiline input
     Multiline = 4,
+    /// Secret input
     Secret = 5,
+    /// Input!
     Input = 7,
+    /// Readonly input
     Readonly = 8,
+    /// Wrap input
     Wrap = 16,
 }
 

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -197,29 +197,52 @@
 
 #![allow(non_upper_case_globals)]
 
+/// Application related methods and functions
 pub mod app;
+/// Browser widgets
 pub mod browser;
+/// Button widgets
 pub mod button;
+/// Dialog widgets
 pub mod dialog;
+/// Drawing primitives
 pub mod draw;
+/// Fltk defined enums: Color, Font, CallbackTrigger etc
 pub mod enums;
+/// Basic fltk box/frame widget
 pub mod frame;
+/// Group widgets
 pub mod group;
+/// Image types supported by fltk
 pub mod image;
+/// Input widgets
 pub mod input;
+/// Menu widgets
 pub mod menu;
+/// Miscellaneous widgets not fitting a certain group
 pub mod misc;
+/// Output widgets
 pub mod output;
+/// All fltk widget traits and flt error types
 pub mod prelude;
+/// Widget surface to image functions
 pub mod surface;
+/// Table widgets
 pub mod table;
+/// Text display widgets
 pub mod text;
+/// Tree widgets
 pub mod tree;
+/// General utility functions
 pub mod utils;
+/// Valuator widgets
 pub mod valuator;
+/// Basic empty widget
 pub mod widget;
+/// Window widgets
 pub mod window;
 
+/// Printing related functions
 #[cfg(not(target_os = "android"))]
 pub mod printer;
 

--- a/fltk/src/menu.rs
+++ b/fltk/src/menu.rs
@@ -47,15 +47,25 @@ pub struct MenuItem {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum MenuFlag {
+    /// Normal item
     Normal = 0,
+    /// Inactive item
     Inactive = 1,
+    /// Item is a checkbox toggle (shows checkbox for on/off state)
     Toggle = 2,
+    /// The on/off state for checkbox/radio buttons (if set, state is 'on')
     Value = 4,
+    /// Item is a radio button
     Radio = 8,
+    /// Invisible item
     Invisible = 0x10,
+    /// Indicates user_data() is a pointer to another menu array (unused with Rust)
     SubmenuPointer = 0x20,
+    /// Menu item is a submenu
     Submenu = 0x40,
+    /// Menu divider
     MenuDivider = 0x80,
+    /// Horizontal menu (actually reserved for future use)
     MenuHorizontal = 0x100,
 }
 

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -13,12 +13,19 @@ use std::{
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum ChartType {
+    /// Bar chart
     Bar = 0,
+    /// Horizontal bar chart
     HorizontalBar = 1,
+    /// Line chart
     Line = 2,
+    /// Fill chart
     Fill = 3,
+    /// Spike chart
     Spike = 4,
+    /// Pie chart
     Pie = 5,
+    /// Special pie chart
     SpecialPie = 6,
 }
 
@@ -26,7 +33,9 @@ pub enum ChartType {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum ClockType {
+    /// Square clock
     Square = 0,
+    /// Round clock
     Round = 1,
 }
 
@@ -689,7 +698,7 @@ impl HelpView {
         );
         unsafe {
             let s = CString::safe_new(s);
-            let ret =  Fl_Help_View_find(s.as_ptr(), start_from as i32);
+            let ret =  Fl_Help_View_find(self._inner, s.as_ptr(), start_from as i32);
             match ret {
                 -1 => None,
                 _ => Some(ret as usize),

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -683,10 +683,17 @@ impl HelpView {
     /// Find a string, returns the index
     pub fn find(&self, s: &str, start_from: usize) -> Option<usize> {
         assert!(!self.was_deleted());
-        if let Some(v) = self.value() {
-            v[start_from..].find(s).map(|idx| start_from + idx)
-        } else {
-            None
+        debug_assert!(
+            start_from <= std::isize::MAX as usize,
+            "usize entries have to be < std::isize::MAX for compatibility!"
+        );
+        unsafe {
+            let s = CString::safe_new(s);
+            let ret =  Fl_Help_View_find(s.as_ptr(), start_from as i32);
+            match ret {
+                -1 => None,
+                _ => Some(ret as usize),
+            }
         }
     }
 

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -6,10 +6,15 @@ use std::{fmt, io};
 /// Error types returned by fltk-rs + wrappers of std::io errors
 #[derive(Debug)]
 pub enum FltkError {
+    /// i/o error
     IoError(io::Error),
+    /// Null string conversion error
     NullError(std::ffi::NulError),
+    /// Internal fltk error
     Internal(FltkErrorKind),
+    /// Error using an errorneous env variable
     EnvVarError(std::env::VarError),
+    /// Unknown error
     Unknown(String),
 }
 
@@ -19,13 +24,21 @@ unsafe impl Sync for FltkError {}
 /// Error kinds enum for FltkError
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum FltkErrorKind {
+    /// Failed to run the application
     FailedToRun,
+    /// Failed to initialize the multithreading
     FailedToLock,
+    /// Failed to set the general scheme of the application
     FailedToSetScheme,
+    /// Failed operation, mostly unknown reason!
     FailedOperation,
+    /// System resource (file, image) not found
     ResourceNotFound,
+    /// Image format error when opening an image of an unsopported format
     ImageFormatError,
+    /// Error filling table
     TableError,
+    /// Error due to printing
     PrintError,
 }
 

--- a/fltk/src/table.rs
+++ b/fltk/src/table.rs
@@ -19,13 +19,21 @@ pub struct Table {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TableContext {
+    /// No context
     None = 0,
+    /// start of page context
     StartPage = 0x01,
+    /// End of page context
     EndPage = 0x02,
+    /// Row header context
     RowHeader = 0x04,
+    /// Column header context
     ColHeader = 0x08,
+    /// Cell context
     Cell = 0x10,
+    /// Table context
     Table = 0x20,
+    /// Row-Column resize context
     RcResize = 0x40,
 }
 
@@ -40,17 +48,23 @@ pub struct TableRow {
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TableRowSelectMode {
-    SelectNone,
-    SelectSingle,
-    SelectMulti,
+    /// Disable select
+    None,
+    /// Select single elements
+    Single,
+    /// Select several elements
+    Multi,
 }
 
 /// Defines the table row select flag
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TableRowSelectFlag {
+    /// Deselect on click
     Deselect,
+    /// Select on click
     Select,
+    /// Toggle selection on click
     Toggle,
 }
 

--- a/fltk/src/text.rs
+++ b/fltk/src/text.rs
@@ -568,9 +568,13 @@ impl Drop for TextBuffer {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum WrapMode {
+    /// No wrapping
     None,
+    /// Wrap text at certain column
     AtColumn,
+    /// Wrap text at certain pixel
     AtPixel,
+    /// Wrap text at certain bounds
     AtBounds,
 }
 
@@ -578,11 +582,16 @@ pub enum WrapMode {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum DragType {
-    DragNone = -2,
-    DragStartDnd = -1,
-    DragChar = 0,
-    DragWord = 1,
-    DragLine = 2,
+    /// No dragging
+    None = -2,
+    /// Drag Start "drag n drop" event
+    StartDnd = -1,
+    /// Drag single character
+    Char = 0,
+    /// Drag single word
+    Word = 1,
+    /// Drag single line
+    Line = 2,
 }
 
 /// Creates a non-editable text display widget
@@ -615,8 +624,11 @@ pub struct SimpleTerminal {
 /// Defines the styles used in the set_highlight_data, which is used with style buffers
 #[derive(Debug, Clone, Copy)]
 pub struct StyleTableEntry {
+    /// Font color
     pub color: Color,
+    /// Font type
     pub font: Font,
+    /// Font size
     pub size: u32,
 }
 

--- a/fltk/src/tree.rs
+++ b/fltk/src/tree.rs
@@ -12,8 +12,11 @@ use std::{
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TreeSort {
+    /// Don't sort
     None = 0,
+    /// Sort ascending
     Ascending = 1,
+    /// Sort descending
     Descending = 2,
 }
 
@@ -21,8 +24,11 @@ pub enum TreeSort {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TreeConnectorStyle {
+    /// No line
     None = 0,
+    /// Dotted line
     Dotted = 1,
+    /// Solid line
     Solid = 2,
 }
 
@@ -30,9 +36,13 @@ pub enum TreeConnectorStyle {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TreeSelect {
+    /// Select none
     None = 0,
+    /// Select single
     Single = 1,
+    /// Select multi
     Multi = 2,
+    /// Select single and make draggable
     SingleDraggable = 3,
 }
 
@@ -40,8 +50,11 @@ pub enum TreeSelect {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TreeItemSelect {
+    /// Deselect when clicked
     Deselect = 0,
+    /// Selected when clicked
     Select = 1,
+    /// Toggle when clicked
     Toggle = 2,
 }
 
@@ -49,12 +62,19 @@ pub enum TreeItemSelect {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TreeReason {
+    /// No callback trigger
     None = 0,
+    /// Trigger callback when selected
     Selected,
+    /// Trigger callback when deselected
     Deselected,
+    /// Trigger callback when reselected
     Reselected,
+    /// Trigger callback when opened
     Opened,
+    /// Trigger callback when closed
     Closed,
+    /// Trigger callback when dragged
     Dragged,
 }
 
@@ -62,7 +82,9 @@ pub enum TreeReason {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TreeItemReselectMode {
+    /// Reselect once
     Once = 0,
+    /// Always reselect
     Always,
 }
 
@@ -70,8 +92,11 @@ pub enum TreeItemReselectMode {
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TreeItemDrawMode {
+    /// Default draw mode
     Default = 0,
+    /// Draws label and widget
     LabelAndWidget = 1,
+    /// Draws the height from widget
     HeightFromWidget = 2,
 }
 
@@ -477,6 +502,7 @@ impl Tree {
         unsafe { Fl_Tree_select_toggle(self._inner, item._inner, do_callback as i32) }
     }
 
+    /// Deselect an item at `path` and determine whether to do the callback
     pub fn deselect(&mut self, path: &str, do_callback: bool) -> Result<(), FltkError> {
         assert!(!self.was_deleted());
         let path = CString::safe_new(path);

--- a/fltk/src/valuator.rs
+++ b/fltk/src/valuator.rs
@@ -25,11 +25,17 @@ pub struct NiceSlider {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum SliderType {
+    /// Vertical slider
     Vertical = 0,
+    /// Horizontal slider
     Horizontal = 1,
+    /// Vertical fill slider
     VerticalFill = 2,
+    /// Horizontal fill slider
     HorizontalFill = 3,
+    /// Vertical nice slider
     VerticalNice = 4,
+    /// Horizontal nice slider
     HorizontalNice = 5,
 }
 
@@ -51,8 +57,11 @@ pub struct LineDial {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum DialType {
+    /// Normal dial
     Normal = 0,
+    /// Line dial
     Line = 1,
+    /// Filled dial
     Fill = 2,
 }
 
@@ -67,7 +76,9 @@ pub struct Counter {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum CounterType {
+    /// Normal counter
     Normal = 0,
+    /// Simple counter
     Simple = 1,
 }
 
@@ -82,11 +93,17 @@ pub struct Scrollbar {
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum ScrollbarType {
+    /// Vertical scrollbar
     Vertical = 0,
+    /// Horizontal scrollbar
     Horizontal = 1,
+    /// Vertical fill scrollbar
     VerticalFill = 2,
+    /// Horizontal fill scrollbar
     HorizontalFill = 3,
+    /// Vertical nice scrollbar
     VerticalNice = 4,
+    /// Horizontal nice scrollbar
     HorizontalNice = 5,
 }
 

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -38,7 +38,9 @@ pub type Window = DoubleWindow;
 #[repr(i32)]
 #[derive(WidgetType, Debug, Copy, Clone, PartialEq)]
 pub enum WindowType {
+    /// Single window
     Normal = 240,
+    /// Double window
     Double = 241,
 }
 


### PR DESCRIPTION
- [BREAKING] Remove deprecated calls app::set_color and calls to scrollbar_width (should be replaced by scrollbar_size).
- [BREAKING] Change Color::BackGround to BackGround2 to better reflect the color of input/output widgets.
- [BREAKING] TableRowSelectMode enum values were trimmed to remove Select prefix.
- [BREAKING] DragType enum values were trimmed to remove Drag prefix.
- FAQ: Add info on keeping the console window only for debug builds on Windows.Thanks @dheijl
- Add proper Default impl for use with fl2rust.
- Add Color::by_index(u8).
- Add WindowExt::hotspot().
- Add Group::current().
- Add ButtonExt and MenuExt down_box().
- Add HelpView and InputChoice widgets in the misc module.
- Add CheckBrowser in the browser module.
- Add app::get_system_colors().
- Update dependencies.
- Add missing docs.