### PR TITLE
0.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.13.5] - 2021-01-15
+### Changes
+- Change dialog::color_chooser's default to white instead of black.
+- Add dialog::color_chooser_with_default().
 
 ## [0.13.4] - 2021-01-13
 ### Changes

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.13.4"
+version = "0.13.5"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk/src/dialog.rs
+++ b/fltk/src/dialog.rs
@@ -976,18 +976,36 @@ pub fn file_chooser(message: &str, pattern: &str, dir: &str, relative: bool) -> 
     }
 }
 
-/// Spawns a color_chooser dialog. `cmode`: Optional mode for color chooser. Default is -1 if rgb mode.
+/// Spawns a color_chooser dialog. 
+/// `cmode`: Optional mode for color chooser. Default is 0 if rgb mode.
 pub fn color_chooser(name: &str, cmode: i32) -> Option<(u8, u8, u8)> {
     unsafe {
         let name = CString::safe_new(name);
-        let mut r = 0;
-        let mut g = 0;
-        let mut b = 0;
+        let mut r = 255;
+        let mut g = 255;
+        let mut b = 255;
         let ret = Fl_color_chooser(name.as_ptr(), &mut r, &mut g, &mut b, cmode);
         if ret == 0 {
             None
         } else {
             Some((r, g, b))
+        }
+    }
+}
+
+/// Spawns a color_chooser dialog. 
+/// `cmode`: Optional mode for color chooser. Default is 0 if rgb mode.
+pub fn color_chooser_with_default(name: &str, cmode: i32, col: (u8, u8, u8)) -> (u8, u8, u8) {
+    unsafe {
+        let name = CString::safe_new(name);
+        let mut r = col.0;
+        let mut g = col.1;
+        let mut b = col.2;
+        let ret = Fl_color_chooser(name.as_ptr(), &mut r, &mut g, &mut b, cmode);
+        if ret == 0 {
+            col
+        } else {
+            (r, g, b)
         }
     }
 }


### PR DESCRIPTION
- Change dialog::color_chooser's default to white instead of black.
- Add dialog::color_chooser_with_default().