### PR TITLE
0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.13.6] - Unreleased
+## [0.13.6] - 2021-01-18
 ### Changes
 - Add debug_assert that char != 0 for BrowserExt::set_format_char and set_column_char.
 - Fix rustdoc failing tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.13.6] - Unreleased
+### Changes
+- Add assert that char != 0 for BrowserExt::set_format_char and set_column_char.
+- Fix rustdoc failing tests.
+
 ## [0.13.5] - 2021-01-15
 ### Changes
 - Change dialog::color_chooser's default to white instead of black.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [0.13.6] - Unreleased
 ### Changes
-- Add assert that char != 0 for BrowserExt::set_format_char and set_column_char.
+- Add debug_assert that char != 0 for BrowserExt::set_format_char and set_column_char.
 - Fix rustdoc failing tests.
+- Add syntactic sugar for DisplayExt::set_buffer to accept Into-Option, same for set_highlight_data.
 
 ## [0.13.5] - 2021-01-15
 ### Changes

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.13.3"
+version = "0.13.6"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/browser.rs
+++ b/fltk-derive/src/browser.rs
@@ -319,7 +319,7 @@ pub fn impl_browser_trait(ast: &DeriveInput) -> TokenStream {
 
             fn set_format_char(&mut self, c: char) {
                 assert!(!self.was_deleted());
-                assert!(c != 0 as char);
+                debug_assert!(c != 0 as char);
                 let c = if c as i32 > 128 { 128 as char } else { c };
                 unsafe {
                     #set_format_char(self._inner, c as raw::c_char)
@@ -335,7 +335,7 @@ pub fn impl_browser_trait(ast: &DeriveInput) -> TokenStream {
 
             fn set_column_char(&mut self, c: char) {
                 assert!(!self.was_deleted());
-                assert!(c != 0 as char);
+                debug_assert!(c != 0 as char);
                 let c = if c as i32 > 128 { 128 as char } else { c };
                 unsafe {
                     #set_column_char(self._inner, c as raw::c_char)

--- a/fltk-derive/src/browser.rs
+++ b/fltk-derive/src/browser.rs
@@ -319,6 +319,7 @@ pub fn impl_browser_trait(ast: &DeriveInput) -> TokenStream {
 
             fn set_format_char(&mut self, c: char) {
                 assert!(!self.was_deleted());
+                assert!(c != 0 as char);
                 let c = if c as i32 > 128 { 128 as char } else { c };
                 unsafe {
                     #set_format_char(self._inner, c as raw::c_char)
@@ -334,6 +335,7 @@ pub fn impl_browser_trait(ast: &DeriveInput) -> TokenStream {
 
             fn set_column_char(&mut self, c: char) {
                 assert!(!self.was_deleted());
+                assert!(c != 0 as char);
                 let c = if c as i32 > 128 { 128 as char } else { c };
                 unsafe {
                     #set_column_char(self._inner, c as raw::c_char)

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.13.5"
+version = "0.13.6"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=0.13.3" }
-fltk-derive = { path = "../fltk-derive", version = "=0.13.3" }
+fltk-derive = { path = "../fltk-derive", version = "=0.13.6" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -172,7 +172,7 @@ impl App {
     /// As such only one font can be loaded at a time.
     /// The font name can be used with Font::by_name, and index with Font::by_index.
     /// # Examples
-    /// ```
+    /// ```no_run
     /// use fltk::*;
     /// let app = app::App::default();
     /// let font = app.load_font("font.ttf").unwrap();
@@ -762,7 +762,9 @@ pub fn event_inside(x: i32, y: i32, w: i32, h: i32) -> bool {
 
 /// Gets the widget that is below the mouse cursor
 /// This returns an Option<impl WidgetExt> which can be specified in the function call
-/// ```rust
+/// ```no_run
+/// use fltk::app;
+/// use fltk::widget;
 /// let w = app::belowmouse::<widget::Widget>(); // or by specifying a more concrete type
 /// ```
 pub fn belowmouse<Wid: WidgetExt>() -> Option<impl WidgetExt> {

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! An example hello world application:
 //!
-//! ```rust
+//! ```no_run
 //!     use fltk::{app::*, window::*};
 //!
 //!     let app = App::default();
@@ -45,7 +45,7 @@
 //! ```
 //!
 //! Another example showing the basic callback functionality:
-//! ```rust
+//! ```no_run
 //!     use fltk::{app::*, button::*, frame::*, window::*};
 //!
 //!     let app = App::default();
@@ -60,7 +60,7 @@
 //! Please check the examples directory for more examples.
 //! You will notice that all widgets are instantiated with a new() method, taking the x and y coordinates, the width and height of the widget, as well as a label which can be left blank if needed. Another way to initialize a widget is using the builder pattern: (The following buttons are equivalent)
 //!
-//! ```rust
+//! ```ignored
 //! let but1 = Button::new(10, 10, 80, 40, "Button 1");
 //!
 //! let but2 = Button::default()
@@ -70,7 +70,7 @@
 //! ```
 //!
 //! An example of a counter showing use of the builder pattern:
-//! ```rust
+//! ```ignored
 //!     let app = app::App::default();
 //!     let mut wind = Window::default()
 //!         .with_size(160, 200)
@@ -97,13 +97,13 @@
 //! ### Events
 //!
 //! Events can be handled using the set_callback method (as above) or the available fltk::app::set_callback() free function, which will handle the default trigger of each widget(like clicks for buttons):
-//! ```rust
+//! ```ignored
 //!     /* previous hello world code */
 //!     but.set_callback(move || frame.set_label("Hello World!"));
 //!     app.run().unwrap();
 //! ```
 //! Another way is to use message passing:
-//! ```rust
+//! ```ignored
 //!     /* previous counter code */
 //!     let (s, r) = app::channel::<Message>();
 //!
@@ -123,7 +123,7 @@
 //! https://github.com/MoAlyousef/fltk-rs/blob/master/examples/counter2.rs
 //!
 //! For custom event handling, the handle() method can be used:
-//! ```rust
+//! ```ignored
 //!     some_widget.handle(move |ev: Event| {
 //!         match ev {
 //!             /* handle ev */
@@ -142,12 +142,12 @@
 //! - Plastic
 //!
 //! These can be set using the App::with_scheme() function.
-//! ```rust
+//! ```ignored
 //! let app = App::default().with_scheme(AppScheme::Gleam);
 //! ```
 //! Themes of individual widgets can be optionally modified using the provided methods in the WidgetBase trait,
 //! such as set_color(), set_label_font(), set_frame() etc:
-//! ```rust
+//! ```ignored
 //!     some_button.set_color(Color::Light1); //! You can use one of the provided colors in the fltk enums
 //!     some_button.set_color(Color::from_rgb(255, 0, 0)); //! Or you can specify a color by rgb or hex/u32 value
 //!     some_button.set_color(Color::from_u32(0xffebee));
@@ -175,23 +175,23 @@
 //! - Linux: X11 and OpenGL development headers need to be installed for development. The libraries themselves are available on linux distros with a graphical user interface.
 //!
 //! For Debian-based GUI distributions, that means running:
-//! ```
+//! ```ignored
 //! $ sudo apt-get install libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libpango1.0-dev libpng-dev libgl1-mesa-dev libglu1-mesa-dev
-//! ```
+//! ```ignored
 //! For RHEL-based GUI distributions, that means running:
-//! ```
+//! ```ignored
 //! $ sudo yum groupinstall "X Software Development" && yum install pango-devel libXinerama-devel libpng-devel
 //! ```
 //! For Arch-based GUI distributions, that means running:
-//! ```
+//! ```ignored
 //! $ sudo pacman -S libx11 libxext libxft libxinerama libxcursor libxrender libxfixes libpng pango cairo libgl mesa --needed
 //! ```
 //! For Alpine linux:
-//! ```
+//! ```ignored
 //! $ apk add pango-dev fontconfig-dev libxinerama-dev libxfixes-dev libxcursor-dev libpng-dev mesa-gl
 //! ```
 //! For NixOS (Linux distribution) this `nix-shell` environment can be used:
-//! ```
+//! ```ignored
 //! $ nix-shell --packages rustc cmake git gcc xorg.libXext xorg.libXft xorg.libXinerama xorg.libXcursor xorg.libXrender xorg.libXfixes libpng libcerf pango cairo libGL mesa pkg-config
 //! ```
 //! - Android: Android Studio, Android Sdk, Android Ndk.

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -668,7 +668,7 @@ pub unsafe trait DisplayExt: WidgetExt {
     /// Get the associated TextBuffer
     fn buffer(&self) -> Option<crate::text::TextBuffer>;
     /// Sets the associated TextBuffer
-    fn set_buffer(&mut self, buffer: Option<crate::text::TextBuffer>);
+    fn set_buffer<B: Into<Option<crate::text::TextBuffer>>>(&mut self, buffer: B);
     /// Get the associated style TextBuffer
     fn style_buffer(&self) -> Option<crate::text::TextBuffer>;
     /// Return the text font
@@ -706,9 +706,9 @@ pub unsafe trait DisplayExt: WidgetExt {
     /// Shows/hides the cursor
     fn show_cursor(&mut self, val: bool);
     /// Sets the style of the text widget
-    fn set_highlight_data(
+    fn set_highlight_data<B: Into<Option<crate::text::TextBuffer>>>(
         &mut self,
-        style_buffer: crate::text::TextBuffer,
+        style_buffer: B,
         entries: Vec<crate::text::StyleTableEntry>,
     );
     /// Sets the cursor style

--- a/fltk/src/utils.rs
+++ b/fltk/src/utils.rs
@@ -18,7 +18,8 @@ impl FlString for CString {
 
 /// Convenience function to convert rgb to hex
 /// Example: 
-/// ```rust
+/// ```no_run
+/// use fltk::utils::rgb2hex;
 /// let ret = rgb2hex(0, 255, 0); println!("0x{:06x}", ret);
 /// ```
 pub fn rgb2hex(r: u8, g: u8, b: u8) -> u32 {
@@ -28,7 +29,8 @@ pub fn rgb2hex(r: u8, g: u8, b: u8) -> u32 {
 
 /// Convenience function to convert hex to rgb
 /// Example:
-/// ```rust
+/// ```no_run
+/// use fltk::utils::hex2rgb;
 /// let (r, g, b) = hex2rgb(0x000000);
 /// ```
 pub fn hex2rgb(val: u32) -> (u8, u8, u8) {


### PR DESCRIPTION
- Add debug_assert that char != 0 for BrowserExt::set_format_char and set_column_char.
- Fix rustdoc failing tests.
- Add syntactic sugar for DisplayExt::set_buffer to accept Into-Option, same for set_highlight_data.