### PR TITLE
0.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.13.6] - 2021-01-18
+## [0.13.7] - 2021-01-18
 ### Changes
 - Add debug_assert that char != 0 for BrowserExt::set_format_char and set_column_char.
 - Fix rustdoc failing tests.

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.13.6"
+version = "0.13.7"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/display.rs
+++ b/fltk-derive/src/display.rs
@@ -228,8 +228,8 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
             fn set_buffer<B: Into<Option<crate::text::TextBuffer>>>(&mut self, buffer: B) {
                 unsafe {
                     assert!(!self.was_deleted());
-                    let _old_buf = self.buffer();
                     if let Some(buffer) = buffer.into() {
+                        let _old_buf = self.buffer();
                         buffer._refcount.fetch_add(1, Ordering::Relaxed);
                         #set_buffer(self._inner, buffer.as_ptr())
                     } else {
@@ -409,8 +409,8 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
                 assert!(self.buffer().is_some());
                 debug_assert!(entries.len() < 29);
                 if entries.len() == 0 { return; }
-                let _old_buf = self.buffer();
                 if let Some(style_buffer) = style_buffer.into() {
+                    let _old_buf = self.style_buffer();
                     style_buffer._refcount.fetch_add(1, Ordering::Relaxed);
                     let mut colors: Vec<u32> = vec![];
                     let mut fonts: Vec<i32> = vec![];
@@ -424,9 +424,7 @@ pub fn impl_display_trait(ast: &DeriveInput) -> TokenStream {
                         #set_highlight_data(self._inner, style_buffer.as_ptr() as *mut raw::c_void, &mut colors[0], &mut fonts[0], &mut sizes[0], entries.len() as i32)
                     }
                 } else {
-                    unsafe {
-                        #set_highlight_data(self._inner, std::ptr::null_mut() as _, 0 as _, 0 as _, 0 as _, 0)
-                    }
+                    return;
                 }
             }
 

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.13.6"
+version = "0.13.7"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=0.13.3" }
-fltk-derive = { path = "../fltk-derive", version = "=0.13.6" }
+fltk-derive = { path = "../fltk-derive", version = "=0.13.7" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 


### PR DESCRIPTION
- Add debug_assert that char != 0 for BrowserExt::set_format_char and set_column_char.
- Fix rustdoc failing tests.
- Add syntactic sugar for DisplayExt::set_buffer to accept Into-Option, same for set_highlight_data.