### PR TITLE
0.13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## [0.13.9] - 2021-01-22
 ### Changes
 - Fix GlWindow::set_mode to account for change of enums::Mode now using bitfalgs.
-- Link OpenGL when using the enable-glwindow feature.
+- Fix linkage with feature enable-glwindow.
 
 ## [0.13.8] - 2021-01-21
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## [0.13.9] - 2021-01-22
+### Changes
+- Fix GlWindow::set_mode to account for change of enums::Mode now using bitfalgs.
+- Link OpenGL when using the enable-glwindow feature.
+
 ## [0.13.8] - 2021-01-21
 ### Changes
 - Add missing assert.

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.13.8"
+version = "0.13.9"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"

--- a/fltk-sys/build.rs
+++ b/fltk-sys/build.rs
@@ -163,7 +163,6 @@ fn main() {
             } else {
                 dst.define("OPTION_USE_PANGO", "ON");
             }
-            
         }
 
         if target_triple.contains("unknown-linux-musl") {
@@ -255,6 +254,17 @@ fn main() {
 
         if cfg!(feature = "enable-glwindow") {
             println!("cargo:rustc-link-lib=static=fltk_gl");
+            match target_os.as_str() {
+                "macos" => println!("cargo:rustc-link-lib=framework=OpenGL"),
+                "windows" => {
+                    println!("cargo:rustc-link-lib=dylib=opengl32");
+                    println!("cargo:rustc-link-lib=dylib=glu32");
+                }
+                _ => {
+                    println!("cargo:rustc-link-lib=dylib=GL");
+                    println!("cargo:rustc-link-lib=dylib=GLU");
+                }
+            }
         }
 
         match target_os.as_str() {

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.13.8"
+version = "0.13.9"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,7 +17,7 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=0.13.8" }
+fltk-sys = { path = "../fltk-sys", version = "=0.13.9" }
 fltk-derive = { path = "../fltk-derive", version = "=0.13.8" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"

--- a/fltk/src/window.rs
+++ b/fltk/src/window.rs
@@ -412,7 +412,7 @@ impl GlWindow {
     pub fn set_mode(&mut self, mode: Mode) {
         assert!(!self.was_deleted());
         unsafe {
-            Fl_Gl_Window_set_mode(self._inner, mode as i32);
+            Fl_Gl_Window_set_mode(self._inner, mode.bits());
         }
     }
 }


### PR DESCRIPTION
- Fix GlWindow::set_mode to account for change of enums::Mode now using bitfalgs.
- Fix linkage with feature enable-glwindow.