### PR TITLE
0.13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## [0.13.9] - 2021-01-22
 ### Changes
 - Fix GlWindow::set_mode to account for change of enums::Mode now using bitfalgs.
-- Link OpenGL when using the enable-glwindow feature.
+- Fix linkage with feature enable-glwindow.
 
 ## [0.13.8] - 2021-01-21
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 ### Changes
 - Fix GlWindow::set_mode to account for change of enums::Mode now using bitfalgs.
 - Fix linkage with feature enable-glwindow.
-
-## [0.13.8] - 2021-01-21
-### Changes
 - Add missing assert.
 - Update cfltk.
 


### PR DESCRIPTION
- Fix GlWindow::set_mode to account for change of enums::Mode now using bitfalgs.
- Fix linkage with feature enable-glwindow.