### PR TITLE
0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
 
-## [0.13.16] - 2021-02-05
+## [0.14.0] - 2021-02-05
 ### Changes
+- [BREAKING] Rename old app::awake<F: FnMut()>(cb: F) to app::awake_callback.
+- [BREAKING] Remove redundant/unnecessary methods from the App struct.
 - Add WidgetExt::draw_framebuffer().
 - Add utils::hex2rgba().
+- Add app::awake().
+- Add custom std::fmt::Debug impl for Event to account for custom events.
+- Update libc dependency.
 
 ## [0.13.15] - 2021-02-04
 ### Changes

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.13.16"
+version = "0.14.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.13.14"
+version = "0.14.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"
@@ -14,7 +14,7 @@ name = "fltk_sys"
 path = "src/lib.rs"
 
 [dependencies]
-libc = "0.2.82"
+libc = "0.2.85"
 
 [build-dependencies]
 cmake = { version = "^0.1.45", git = "https://github.com/moalyousef/cmake-rs" }

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.13.16"
+version = "0.14.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=0.13.14" }
-fltk-derive = { path = "../fltk-derive", version = "=0.13.16" }
+fltk-sys = { path = "../fltk-sys", version = "=0.14.0" }
+fltk-derive = { path = "../fltk-derive", version = "=0.14.0" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 gl_loader = { version = "^0.1.2", optional = true }

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -389,7 +389,7 @@ impl std::fmt::Display for Color {
 
 /// Defines event types captured by FLTK
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Event {
     /// No Event
     NoEvent = 0,
@@ -456,14 +456,54 @@ impl Event {
     /// # Safety
     /// The i32 value might not have a representation within the enum
     /// This should be taken into account in fmt::Debug for example
-    pub unsafe fn from_i32(val: i32) -> Event {
-        std::mem::transmute(val)
+    pub fn from_i32(val: i32) -> Event {
+        unsafe { std::mem::transmute(val) }
     }
 }
 
 impl Into<i32> for Event {
     fn into(self) -> i32 {
         self as i32
+    }
+}
+
+#[allow(unreachable_patterns)]
+impl std::fmt::Debug for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Event::NoEvent => write!(f, "NoEvent"),
+            Event::Push => write!(f, "Push"),
+            Event::Released => write!(f, "Released"),
+            Event::Enter => write!(f, "Enter"),
+            Event::Leave => write!(f, "Leave"),
+            Event::Drag => write!(f, "Drag"),
+            Event::Focus => write!(f, "Focus"),
+            Event::Unfocus => write!(f, "Unfocus"),
+            Event::KeyDown => write!(f, "KeyDown"),
+            Event::KeyUp => write!(f, "KeyUp"),
+            Event::Close => write!(f, "Close"),
+            Event::Move => write!(f, "Move"),
+            Event::Shortcut => write!(f, "Shortcut"),
+            Event::Deactivate => write!(f, "Deactivate"),
+            Event::Activate => write!(f, "Activate"),
+            Event::Hide => write!(f, "Hide"),
+            Event::Show => write!(f, "Show"),
+            Event::Paste => write!(f, "Paste"),
+            Event::SelectionClear => write!(f, "SelectionClear"),
+            Event::MouseWheel => write!(f, "MouseWheel"),
+            Event::DndEnter => write!(f, "DndEnter"),
+            Event::DndDrag => write!(f, "DndDrag"),
+            Event::DndLeave => write!(f, "DndLeave"),
+            Event::DndRelease => write!(f, "DndRelease"),
+            Event::ScreenConfigChanged => write!(f, "ScreenConfigChanged"),
+            Event::Fullscreen => write!(f, "Fullscreen"),
+            Event::ZoomGesture => write!(f, "ZoomGesture"),
+            Event::ZoomEvent => write!(f, "ZoomEvent"),
+            Event::Resize => write!(f, "Resize"),
+            _ => {
+                write!(f, "Event::from_i32({})", *self as i32)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- [BREAKING] Rename old app::awake<F: FnMut()>(cb: F) to app::awake_callback.
- [BREAKING] Remove redundant/unnecessary methods from the App struct.
- Add WidgetExt::draw_framebuffer().
- Add utils::hex2rgba().
- Add app::awake().
- Add custom std::fmt::Debug impl for Event to account for custom events.
- Update libc dependency.