### PR TITLE
Expose Fl:event_key(int key)

### DIFF
--- a/fltk-sys/src/fl.rs
+++ b/fltk-sys/src/fl.rs
@@ -39,6 +39,9 @@ extern "C" {
     pub fn Fl_event_key() -> libc::c_int;
 }
 extern "C" {
+    pub fn Fl_event_key_down(key: libc::c_int) -> libc::c_int;
+}
+extern "C" {
     pub fn Fl_event_text() -> *const libc::c_char;
 }
 extern "C" {

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -269,6 +269,13 @@ pub fn event_key() -> Key {
     }
 }
 
+/// Returns whether the  key is pressed
+pub fn event_key_down(key: Key) -> bool {
+    unsafe {
+        Fl_event_key_down(mem::transmute(key)) != 0
+    }
+}
+
 /// Returns a textual representation of the latest event
 pub fn event_text() -> String {
     unsafe {
@@ -1042,7 +1049,7 @@ pub fn get_system_colors() {
 /// });
 /// ```
 /// # Safety
-/// Can send an arbitrary message to the window, 
+/// Can send an arbitrary message to the window,
 /// which can't be debug formatted as an Event enum.
 /// Sent values should also not conflict with an existing Event's i32 value
 pub unsafe fn handle<I: Into<i32>, W: WindowExt>(msg: I, w: &W) -> bool {
@@ -1065,7 +1072,7 @@ pub unsafe fn handle<I: Into<i32>, W: WindowExt>(msg: I, w: &W) -> bool {
 /// });
 /// ```
 /// # Safety
-/// Can send an arbitrary message to the window, 
+/// Can send an arbitrary message to the window,
 /// which can't be debug formatted as an Event enum.
 /// Sent values should also not conflict with an existing Event's i32 value
 pub unsafe fn handle_main<I: Into<i32>>(msg: I) -> bool {


### PR DESCRIPTION
Fl::event_key() is overloaded with a version that takes a key and returns true if the given key was held down (or pressed) during the last event. This makes it easier for games to check the current state of the key without waiting for a repeat event.