### PR TITLE
0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
 
-## [0.13.16] - 2021-02-05
+## [0.14.0] - 2021-02-05
 ### Changes
+- [BREAKING] Rename old app::awake<F: FnMut()>(cb: F) to app::awake_callback.
+- [BREAKING] Remove redundant/unnecessary methods from the App struct.
 - Add WidgetExt::draw_framebuffer().
 - Add utils::hex2rgba().
+- Add app::awake().
+- Add custom std::fmt::Debug impl for Event to account for custom events.
+- Update libc dependency.
 
 ## [0.13.15] - 2021-02-04
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.14.1] - 2021-02-06
+### Changes
+- Add app::event_key_down(Key) which takes a key and returns true if the given key was held down (or pressed) during the last event. Thanks @CaseyB.
 
 ## [0.14.0] - 2021-02-05
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changelog
 
-## [0.14.1] - 2021-02-06
-### Changes
-- Add app::event_key_down(Key) which takes a key and returns true if the given key was held down (or pressed) during the last event. Thanks @CaseyB.
 
-## [0.14.0] - 2021-02-05
+## [0.14.1] - 2021-02-06
 ### Changes
 - [BREAKING] Rename old app::awake<F: FnMut()>(cb: F) to app::awake_callback.
 - [BREAKING] Remove redundant/unnecessary methods from the App struct.
-- Add WidgetExt::draw_framebuffer().
+- Add app::event_key_down(Key) which takes a key and returns true if the given key was held down (or pressed) during the last event. Thanks @CaseyB.
+- Add framebuffer drawing functions: draw::draw_rgba(), draw_rgba_nocopy(), draw_rgb() and draw_rgb_nocopy().
 - Add utils::hex2rgba().
 - Add app::awake().
 - Add custom std::fmt::Debug impl for Event to account for custom events.

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.13.16"
+version = "0.14.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -1001,25 +1001,6 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
             unsafe fn into_widget<W: WidgetBase>(&self) -> W where Self: Sized {
                 unsafe { W::from_widget_ptr(self.as_widget_ptr() as *mut _) }
             }
-
-            unsafe fn draw_framebuffer(&mut self, fb: &[u8]) -> Result<(), FltkError> {
-                let ptr = fb.as_ptr();
-                let len = fb.len();
-                let width = self.width() as u32;
-                let height = self.height() as u32; 
-                self.draw2(move |s| {
-                    let x = s.x();
-                    let y = s.y();
-                    let w = s.width();
-                    let h = s.height();
-                    let mut img = unsafe { 
-                        crate::image::RgbImage::from_data(std::slice::from_raw_parts(ptr, len), width, height, 4).unwrap() 
-                    };
-                    img.scale(w, h, false, true);
-                    img.draw(x, y, w, h);
-                });
-                Ok(())
-            }
         }
     };
     gen.into()

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.13.14"
+version = "0.14.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"
@@ -14,7 +14,7 @@ name = "fltk_sys"
 path = "src/lib.rs"
 
 [dependencies]
-libc = "0.2.82"
+libc = "0.2.85"
 
 [build-dependencies]
 cmake = { version = "^0.1.45", git = "https://github.com/moalyousef/cmake-rs" }

--- a/fltk-sys/src/fl.rs
+++ b/fltk-sys/src/fl.rs
@@ -39,6 +39,9 @@ extern "C" {
     pub fn Fl_event_key() -> libc::c_int;
 }
 extern "C" {
+    pub fn Fl_event_key_down(key: libc::c_int) -> libc::c_int;
+}
+extern "C" {
     pub fn Fl_event_text() -> *const libc::c_char;
 }
 extern "C" {

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=0.14.0" }
-fltk-derive = { path = "../fltk-derive", version = "=0.14.0" }
+fltk-sys = { path = "../fltk-sys", version = "=0.14.1" }
+fltk-derive = { path = "../fltk-derive", version = "=0.14.1" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 gl_loader = { version = "^0.1.2", optional = true }

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.13.16"
+version = "0.14.0"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=0.13.14" }
-fltk-derive = { path = "../fltk-derive", version = "=0.13.16" }
+fltk-sys = { path = "../fltk-sys", version = "=0.14.0" }
+fltk-derive = { path = "../fltk-derive", version = "=0.14.0" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 gl_loader = { version = "^0.1.2", optional = true }

--- a/fltk/examples/composite_widgets.rs
+++ b/fltk/examples/composite_widgets.rs
@@ -1,0 +1,62 @@
+use fltk::*;
+use std::ops::{Deref, DerefMut};
+
+struct MyButton {
+    grp: group::Group,
+    btn: button::Button,
+}
+
+impl MyButton {
+    pub fn new(w: i32, h: i32, label: &str) -> MyButton {
+        let mut grp = group::Group::new(0, 0, w, h, label);
+        grp.set_frame(FrameType::RFlatBox);
+        grp.set_color(Color::from_u32(0x01579b));
+        grp.set_align(Align::Center);
+        let mut btn = button::Button::new(grp.x() + 420, grp.y() + 35, 15, 15, "X");
+        btn.set_frame(FrameType::OFlatFrame);
+        btn.set_color(Color::from_u32(0xf49da9));
+        btn.set_callback2(move |b| b.parent().unwrap().hide());
+        grp.end();
+        grp.handle2(|g, ev| match ev {
+            Event::Push => {
+                g.do_callback();
+                true
+            }
+            _ => false,
+        });
+        MyButton { grp, btn }
+    }
+}
+
+impl Deref for MyButton {
+    type Target = group::Group;
+    fn deref(&self) -> &Self::Target {
+        &self.grp
+    }
+}
+impl DerefMut for MyButton {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.grp
+    }
+}
+
+fn main() {
+    let app = app::App::default();
+    app::set_visible_focus(false);
+    let mut win = window::Window::default().with_size(500, 400);
+    win.make_resizable(true);
+    win.set_color(Color::Black);
+    let mut pack = group::Pack::default().size_of(&win);
+    pack.set_spacing(10);
+
+    for i in 0..3 {
+        let label = format!("Button {}", i + 1);
+        let mut but = MyButton::new(500, 100, &label);
+        but.set_callback(move || println!("{}", label));
+    }
+
+    pack.end();
+    win.end();
+    win.show();
+    app.run().unwrap();
+}

--- a/fltk/examples/fb.rs
+++ b/fltk/examples/fb.rs
@@ -14,8 +14,8 @@ fn main() {
         fb.push(0x20); // blue
         fb.push(0xfa); // alpha
     }
-    unsafe {
-        frame.draw_framebuffer(&fb).unwrap();
-    }
+    
+    draw::draw_rgba(&mut frame, &fb).unwrap();
+
     app.run().unwrap();
 }

--- a/fltk/examples/fb2.rs
+++ b/fltk/examples/fb2.rs
@@ -1,4 +1,4 @@
-use fltk::{app, frame, prelude::*, window::Window};
+use fltk::{app, frame, draw, prelude::*, window::Window};
 use std::{thread, time::Duration};
 
 const WIDTH: u32 = 320;
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut framebuf: Vec<u8> = vec![0; (WIDTH * HEIGHT * 4) as usize];
     let mut world = World::new();
-    unsafe { frame.draw_framebuffer(&framebuf).unwrap(); }
+    unsafe { draw::draw_rgba_nocopy(&mut frame, &framebuf); }
 
     Ok(while app.wait() {
         world.update();

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -269,7 +269,7 @@ pub fn event_key() -> Key {
     }
 }
 
-/// Returns whether the  key is pressed
+/// Returns whether the  key is pressed or held down during the last event
 pub fn event_key_down(key: Key) -> bool {
     unsafe {
         Fl_event_key_down(mem::transmute(key)) != 0

--- a/fltk/src/app.rs
+++ b/fltk/src/app.rs
@@ -269,6 +269,13 @@ pub fn event_key() -> Key {
     }
 }
 
+/// Returns whether the  key is pressed
+pub fn event_key_down(key: Key) -> bool {
+    unsafe {
+        Fl_event_key_down(mem::transmute(key)) != 0
+    }
+}
+
 /// Returns a textual representation of the latest event
 pub fn event_text() -> String {
     unsafe {
@@ -1042,7 +1049,7 @@ pub fn get_system_colors() {
 /// });
 /// ```
 /// # Safety
-/// Can send an arbitrary message to the window, 
+/// Can send an arbitrary message to the window,
 /// which can't be debug formatted as an Event enum.
 /// Sent values should also not conflict with an existing Event's i32 value
 pub unsafe fn handle<I: Into<i32>, W: WindowExt>(msg: I, w: &W) -> bool {
@@ -1065,7 +1072,7 @@ pub unsafe fn handle<I: Into<i32>, W: WindowExt>(msg: I, w: &W) -> bool {
 /// });
 /// ```
 /// # Safety
-/// Can send an arbitrary message to the window, 
+/// Can send an arbitrary message to the window,
 /// which can't be debug formatted as an Event enum.
 /// Sent values should also not conflict with an existing Event's i32 value
 pub unsafe fn handle_main<I: Into<i32>>(msg: I) -> bool {

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -703,6 +703,79 @@ pub fn capture_window<Win: WindowExt>(win: &mut Win) -> Result<RgbImage, FltkErr
     }
 }
 
+/// Draw a framebuffer (rgba) into a widget
+pub fn draw_rgba<'a, T: WidgetBase>(wid: &'a mut T, fb: &'a [u8]) -> Result<(), FltkError> {
+    let width = wid.width() as u32;
+    let height = wid.height() as u32;
+    let mut img = crate::image::RgbImage::new(fb, width, height, 4)?;
+    wid.draw2(move |s| {
+        let x = s.x();
+        let y = s.y();
+        let w = s.width();
+        let h = s.height();
+        img.scale(w, h, false, true);
+        img.draw(x, y, w, h);
+    });
+    Ok(())
+}
+
+/// Draw a framebuffer (rgba) into a widget
+/// # Safety
+/// - The data passed should be valid and outlive the widget
+pub unsafe fn draw_rgba_nocopy<T: WidgetBase>(wid: &mut T, fb: &[u8]) {
+    let ptr = fb.as_ptr();
+    let len = fb.len();
+    let width = wid.width() as u32;
+    let height = wid.height() as u32; 
+    wid.draw2(move |s| {
+        let x = s.x();
+        let y = s.y();
+        let w = s.width();
+        let h = s.height();
+        if let Ok(mut img) = crate::image::RgbImage::from_data(std::slice::from_raw_parts(ptr, len), width, height, 4) {
+            img.scale(w, h, false, true);
+            img.draw(x, y, w, h);
+        }
+    });
+}
+
+
+/// Draw a framebuffer (rgba) into a widget
+pub fn draw_rgb<'a, T: WidgetBase>(wid: &'a mut T, fb: &'a [u8]) -> Result<(), FltkError> {
+    let width = wid.width() as u32;
+    let height = wid.height() as u32;
+    let mut img = crate::image::RgbImage::new(fb, width, height, 3)?;
+    wid.draw2(move |s| {
+        let x = s.x();
+        let y = s.y();
+        let w = s.width();
+        let h = s.height();
+        img.scale(w, h, false, true);
+        img.draw(x, y, w, h);
+    });
+    Ok(())
+}
+
+/// Draw a framebuffer (rgba) into a widget
+/// # Safety
+/// - The data passed should be valid and outlive the widget
+pub unsafe fn draw_rgb_nocopy<T: WidgetBase>(wid: &mut T, fb: &[u8]) {
+    let ptr = fb.as_ptr();
+    let len = fb.len();
+    let width = wid.width() as u32;
+    let height = wid.height() as u32; 
+    wid.draw2(move |s| {
+        let x = s.x();
+        let y = s.y();
+        let w = s.width();
+        let h = s.height();
+        if let Ok(mut img) = crate::image::RgbImage::from_data(std::slice::from_raw_parts(ptr, len), width, height, 3) {
+            img.scale(w, h, false, true);
+            img.draw(x, y, w, h);
+        }
+    });
+}
+
 /// Transforms raw data to png file
 pub fn write_to_png_file<I: ImageExt, P: AsRef<std::path::Path>>(
     image: &I,

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -389,7 +389,7 @@ impl std::fmt::Display for Color {
 
 /// Defines event types captured by FLTK
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Event {
     /// No Event
     NoEvent = 0,
@@ -456,14 +456,54 @@ impl Event {
     /// # Safety
     /// The i32 value might not have a representation within the enum
     /// This should be taken into account in fmt::Debug for example
-    pub unsafe fn from_i32(val: i32) -> Event {
-        std::mem::transmute(val)
+    pub fn from_i32(val: i32) -> Event {
+        unsafe { std::mem::transmute(val) }
     }
 }
 
 impl Into<i32> for Event {
     fn into(self) -> i32 {
         self as i32
+    }
+}
+
+#[allow(unreachable_patterns)]
+impl std::fmt::Debug for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Event::NoEvent => write!(f, "NoEvent"),
+            Event::Push => write!(f, "Push"),
+            Event::Released => write!(f, "Released"),
+            Event::Enter => write!(f, "Enter"),
+            Event::Leave => write!(f, "Leave"),
+            Event::Drag => write!(f, "Drag"),
+            Event::Focus => write!(f, "Focus"),
+            Event::Unfocus => write!(f, "Unfocus"),
+            Event::KeyDown => write!(f, "KeyDown"),
+            Event::KeyUp => write!(f, "KeyUp"),
+            Event::Close => write!(f, "Close"),
+            Event::Move => write!(f, "Move"),
+            Event::Shortcut => write!(f, "Shortcut"),
+            Event::Deactivate => write!(f, "Deactivate"),
+            Event::Activate => write!(f, "Activate"),
+            Event::Hide => write!(f, "Hide"),
+            Event::Show => write!(f, "Show"),
+            Event::Paste => write!(f, "Paste"),
+            Event::SelectionClear => write!(f, "SelectionClear"),
+            Event::MouseWheel => write!(f, "MouseWheel"),
+            Event::DndEnter => write!(f, "DndEnter"),
+            Event::DndDrag => write!(f, "DndDrag"),
+            Event::DndLeave => write!(f, "DndLeave"),
+            Event::DndRelease => write!(f, "DndRelease"),
+            Event::ScreenConfigChanged => write!(f, "ScreenConfigChanged"),
+            Event::Fullscreen => write!(f, "Fullscreen"),
+            Event::ZoomGesture => write!(f, "ZoomGesture"),
+            Event::ZoomEvent => write!(f, "ZoomEvent"),
+            Event::Resize => write!(f, "Resize"),
+            _ => {
+                write!(f, "Event::from_i32({})", *self as i32)
+            }
+        }
     }
 }
 

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -289,12 +289,6 @@ pub unsafe trait WidgetExt {
     unsafe fn into_widget<W: WidgetBase>(&self) -> W
     where
         Self: Sized;
-    /// Draw a frame buffer (rgba) into the widget
-    /// # Safety
-    /// - The data passed should be valid and outlive the widget
-    /// - Doesn't work on window widgets
-    /// - Hex color values 0x00000000 don't fit on u8, so the fb slice len should account for that
-    unsafe fn draw_framebuffer(&mut self, fb: &[u8]) -> Result<(), FltkError>;
 }
 
 /// Defines the extended methods implemented by all widgets


### PR DESCRIPTION
- [BREAKING] Rename old app::awake<F: FnMut()>(cb: F) to app::awake_callback.
- [BREAKING] Remove redundant/unnecessary methods from the App struct.
- Add app::event_key_down(Key) which takes a key and returns true if the given key was held down (or pressed) during the last event. Thanks @CaseyB.
- Add framebuffer drawing functions: draw::draw_rgba(), draw_rgba_nocopy(), draw_rgb() and draw_rgb_nocopy().
- Add utils::hex2rgba().
- Add app::awake().
- Add custom std::fmt::Debug impl for Event to account for custom events.
- Update libc dependency.