### PR TITLE
Add InputChoice::input

### DIFF
--- a/fltk-sys/src/misc.rs
+++ b/fltk-sys/src/misc.rs
@@ -2206,6 +2206,9 @@ extern "C" {
     pub fn Fl_Input_Choice_set_value2(self_: *mut Fl_Input_Choice, val: libc::c_int);
 }
 extern "C" {
+    pub fn Fl_Input_Choice_input(self_: *mut Fl_Input_Choice) -> *mut libc::c_void;
+}
+extern "C" {
     pub fn Fl_Input_Choice_menu_button(self_: *mut Fl_Input_Choice) -> *mut libc::c_void;
 }
 extern "C" {

--- a/fltk/src/misc.rs
+++ b/fltk/src/misc.rs
@@ -598,6 +598,16 @@ impl InputChoice {
         unsafe { Fl_Input_Choice_set_value2(self._inner, val as i32) }
     }
 
+    /// Get the associated input
+    pub fn input(&self) -> Box<dyn InputExt> {
+        assert!(!self.was_deleted());
+        unsafe {
+            let ptr = Fl_Input_Choice_input(self._inner);
+            assert!(!ptr.is_null());
+            Box::new(crate::input::Input::from_widget_ptr(ptr as _))
+        }
+    }
+
     /// Get the associated menu button
     pub fn menu_button(&self) -> Box<dyn MenuExt> {
         assert!(!self.was_deleted());


### PR DESCRIPTION
Add `InputChoice::input` method, for getting the associated `Input` from an `InputChoice`. Corresponds to [`Fl_Input_Choice::input`][1].

[1]: https://www.fltk.org/doc-1.3/classFl__Input__Choice.html#a7e863b5c9a096f52a9502619d11a7cd0