### PR TITLE
0.14.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## [0.14.10] - 2021-02-14
+
+## [0.14.10] - 2021-02-16
 ### Changes
 - Mark draw::draw_image() as unsafe.
 - Add docs regarding label's special symbols.
+- Add enable-glwindow to docs.rs metadata.
 
 ## [0.14.9] - 2021-02-14
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.14.10] - 2021-02-14
+### Changes
+- Mark draw::draw_image() as unsafe.
+- Add docs regarding label's special symbols.
+
 ## [0.14.9] - 2021-02-14
 ### Changes
 - Add draw::draw_image().

--- a/fltk-sys/build.rs
+++ b/fltk-sys/build.rs
@@ -88,7 +88,7 @@ fn main() {
         println!("cargo:rerun-if-changed=cfltk/src/cfl_printer.cpp");
 
         Command::new("git")
-            .args(&["submodule", "update", "--depth", "1", "--init", "--recursive"])
+            .args(&["submodule", "update", "--init", "--recursive"])
             .current_dir(manifest_dir.clone())
             .status()
             .expect("Git is needed to retrieve the fltk source files!");

--- a/fltk-sys/build.rs
+++ b/fltk-sys/build.rs
@@ -88,7 +88,7 @@ fn main() {
         println!("cargo:rerun-if-changed=cfltk/src/cfl_printer.cpp");
 
         Command::new("git")
-            .args(&["submodule", "update", "--init", "--recursive"])
+            .args(&["submodule", "update", "--depth", "1", "--init", "--recursive"])
             .current_dir(manifest_dir.clone())
             .status()
             .expect("Git is needed to retrieve the fltk source files!");

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -40,3 +40,6 @@ fltk-bundled = ["fltk-sys/fltk-bundled"] # Support for bundled versions of cfltk
 enable-glwindow = ["fltk-sys/enable-glwindow", "gl_loader"] # Support for systems without OpenGL
 no-images = ["fltk-sys/no-images"] # (Experimental) You can use this feature if your app doesn't use images to reduce binary size
 no-pango = ["fltk-sys/no-pango"] # (Experimental and Linux only) You can use this if you don't need rtl or cjk unicode support
+
+[package.metadata.docs.rs]
+features = ["enable-glwindow"]

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.14.9"
+version = "0.14.10"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -787,8 +787,10 @@ pub unsafe fn draw_rgb_nocopy<T: WidgetBase>(wid: &mut T, fb: &[u8]) {
 
 /// Draw an image into a widget
 /// Requires a call to app::set_visual(Mode::Rgb).unwrap()
-pub fn draw_image(data: &[u8], x: i32, y: i32, w: i32, h: i32, depth: i32) {
-    unsafe { Fl_draw_image(data.as_ptr(), x, y, w, h, depth, 0) }
+/// # Safety
+/// The image should be a valid RGB image
+pub unsafe fn draw_image(data: &[u8], x: i32, y: i32, w: i32, h: i32, depth: i32) {
+    Fl_draw_image(data.as_ptr(), x, y, w, h, depth, 0)
 }
 
 /// Transforms raw data to png file

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -89,6 +89,8 @@ pub unsafe trait WidgetExt {
     /// Set to dimensions width and height
     fn set_size(&mut self, width: i32, height: i32);
     /// Sets the widget's label
+    /// labels support special symbols preceded by an `@` [sign](https://www.fltk.org/doc-1.3/symbols.png)
+    /// and for the [associated formatting](https://www.fltk.org/doc-1.3/common.html).
     fn set_label(&mut self, title: &str);
     /// Redraws a widget, necessary for resizing and changing positions
     fn redraw(&mut self);
@@ -300,6 +302,8 @@ pub unsafe trait WidgetBase: WidgetExt {
     /// * `width` - The width of the widget
     /// * `heigth` - The height of the widget
     /// * `title` - The title or label of the widget
+    /// labels support special symbols preceded by an `@` [sign](https://www.fltk.org/doc-1.3/symbols.png)
+    /// and for the [associated formatting](https://www.fltk.org/doc-1.3/common.html).
     fn new(x: i32, y: i32, width: i32, height: i32, title: &str) -> Self;
     /// Deletes widgets and their children.
     fn delete(wid: Self)


### PR DESCRIPTION
- Mark draw::draw_image() as unsafe.
- Add docs regarding label's special symbols.
- Add enable-glwindow to docs.rs metadata.