### PR TITLE
0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 
 
-## [0.15.0] - 2021-02-20
+## [0.15.1] - 2021-02-20
 ### Changes
+- [BREAKING] RgbImage::new() and draw::draw_image() take a ColorDepth enum instead of an int.
 - [BREAKING] Remove app::delay().
 - [BREAKING] Remove image related LabelType values.
 - [BREAKING] Change iconsize and set_iconsize to icon_size and set_icon_size.
 - [BREAKING] BrowserExt::topline, middleline and bottomline converted to snake case.
 - [BREAKING] app::wait_for returns a Result<bool, FltkError>.
-- Fix temp file creation when lacking TMPDIR env variable.
+- Fix temp file creation when lacking TMPDIR env variable on some systems.
 - Fix doc tests.
 - Add tests directory.
 - Update FLTK and cfltk.

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/image.rs
+++ b/fltk-derive/src/image.rs
@@ -100,7 +100,7 @@ pub fn impl_image_trait(ast: &DeriveInput) -> TokenStream {
                     let ptr = #data(self._inner);
                     assert!(!ptr.is_null());
                     assert!(!(*ptr).is_null());
-                    let cnt = self.data_w() * self.data_h() * self.depth();
+                    let cnt = self.data_w() * self.data_h() * self.depth() as u32;
                     let ret: &[u8] = std::slice::from_raw_parts(*ptr as *const u8, cnt as usize);
                     ret.to_vec()
                 }
@@ -147,10 +147,10 @@ pub fn impl_image_trait(ast: &DeriveInput) -> TokenStream {
                 }
             }
 
-            fn depth(&self) -> u32 {
+            fn depth(&self) -> ColorDepth {
                 assert!(!self.was_deleted());
                 unsafe {
-                    #d(self._inner) as u32
+                    mem::transmute(#d(self._inner) as u8)
                 }
             }
 

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=0.15.0" }
-fltk-derive = { path = "../fltk-derive", version = "=0.15.0" }
+fltk-derive = { path = "../fltk-derive", version = "=0.15.1" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 gl_loader = { version = "^0.1.2", optional = true }

--- a/fltk/examples/counter2.rs
+++ b/fltk/examples/counter2.rs
@@ -8,7 +8,7 @@ pub enum Message {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = app::App::default();
-    let mut wind = Window::new(200, 200, 160, 200, "Counter");
+    let mut wind = Window::default().with_size(160, 200).with_label("Counter");
     let mut frame = Frame::new(30, 80, 100, 40, "0");
     let mut but_inc = Button::new(30, 40, 100, 40, "+");
     let mut but_dec = Button::new(30, 120, 100, 40, "-");
@@ -23,10 +23,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     while app.wait() {
         let label: i32 = frame.label().parse()?;
 
-        match r.recv() {
-            Some(Message::Increment) => frame.set_label(&(label + 1).to_string()),
-            Some(Message::Decrement) => frame.set_label(&(label - 1).to_string()),
-            None => (),
+        if let Some(msg) = r.recv() {
+            match msg {
+                Message::Increment => frame.set_label(&(label + 1).to_string()),
+                Message::Decrement => frame.set_label(&(label - 1).to_string()),
+            }
         }
     }
     Ok(())

--- a/fltk/examples/rgb.rs
+++ b/fltk/examples/rgb.rs
@@ -6,23 +6,16 @@ fn main() {
     let mut frame = frame::Frame::new(0, 0, 400, 400, "");
     frame.draw2(|f| {
         let mut image = {
-            let t: Vec<u32> = (0..128 * 128 * 3)
-                .map(|i| {
-                    let x = i % 128;
-                    let y = i / 128;
-                    x ^ y
-                })
-                .collect();
-            let mut v: Vec<u8> = vec![];
-            for elem in t {
-                let (r, g, b) = utils::hex2rgb(elem);
-                v.push(r);
-                v.push(g);
-                v.push(b);
+            let mut v: Vec<u8> = vec![0u8; 128 * 128 * 3];
+            for (i, pixel) in v.chunks_exact_mut(3).enumerate() {
+                let x = i % 128;
+                let y = i / 128;
+                let (r, g, b) = utils::hex2rgb((x ^ y) as u32);
+                pixel.copy_from_slice(&[r, g, b]);
             }
-            image::RgbImage::new(&v, 128, 128, 3).unwrap()
+            image::RgbImage::new(&v, 128, 128, ColorDepth::Rgb8).unwrap()
         };
-        image.scale(400, 400, false, true);
+        image.scale(f.width(), f.height(), false, true);
         image.draw(f.x(), f.y(), f.width(), f.height());
     });
     wind.make_resizable(true);

--- a/fltk/examples/rgb.rs
+++ b/fltk/examples/rgb.rs
@@ -6,15 +6,21 @@ fn main() {
     let mut frame = frame::Frame::new(0, 0, 400, 400, "");
     frame.draw2(|f| {
         let mut image = {
-            let v: Vec<u32> = (0..128 * 128)
+            let t: Vec<u32> = (0..128 * 128 * 3)
                 .map(|i| {
                     let x = i % 128;
                     let y = i / 128;
                     x ^ y
                 })
                 .collect();
-            let v: Vec<u8> = v.into_iter().map(|i| i as u8).collect();
-            image::RgbImage::new(&v, 128, 128, 1).unwrap()
+            let mut v: Vec<u8> = vec![];
+            for elem in t {
+                let (r, g, b) = utils::hex2rgb(elem);
+                v.push(r);
+                v.push(g);
+                v.push(b);
+            }
+            image::RgbImage::new(&v, 128, 128, 3).unwrap()
         };
         image.scale(400, 400, false, true);
         image.draw(f.x(), f.y(), f.width(), f.height());

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -706,7 +706,7 @@ pub fn capture_window<Win: WindowExt>(win: &mut Win) -> Result<RgbImage, FltkErr
                 x,
                 win.width() as u32,
                 win.height() as u32,
-                3,
+                ColorDepth::Rgb8,
             )?)
         }
     }
@@ -716,7 +716,7 @@ pub fn capture_window<Win: WindowExt>(win: &mut Win) -> Result<RgbImage, FltkErr
 pub fn draw_rgba<'a, T: WidgetBase>(wid: &'a mut T, fb: &'a [u8]) -> Result<(), FltkError> {
     let width = wid.width() as u32;
     let height = wid.height() as u32;
-    let mut img = crate::image::RgbImage::new(fb, width, height, 4)?;
+    let mut img = crate::image::RgbImage::new(fb, width, height, ColorDepth::Rgba8)?;
     wid.draw2(move |s| {
         let x = s.x();
         let y = s.y();
@@ -745,7 +745,7 @@ pub unsafe fn draw_rgba_nocopy<T: WidgetBase>(wid: &mut T, fb: &[u8]) {
             std::slice::from_raw_parts(ptr, len),
             width,
             height,
-            4,
+            ColorDepth::Rgba8,
         ) {
             img.scale(w, h, false, true);
             img.draw(x, y, w, h);
@@ -757,7 +757,7 @@ pub unsafe fn draw_rgba_nocopy<T: WidgetBase>(wid: &mut T, fb: &[u8]) {
 pub fn draw_rgb<'a, T: WidgetBase>(wid: &'a mut T, fb: &'a [u8]) -> Result<(), FltkError> {
     let width = wid.width() as u32;
     let height = wid.height() as u32;
-    let mut img = crate::image::RgbImage::new(fb, width, height, 3)?;
+    let mut img = crate::image::RgbImage::new(fb, width, height, ColorDepth::Rgb8)?;
     wid.draw2(move |s| {
         let x = s.x();
         let y = s.y();
@@ -786,7 +786,7 @@ pub unsafe fn draw_rgb_nocopy<T: WidgetBase>(wid: &mut T, fb: &[u8]) {
             std::slice::from_raw_parts(ptr, len),
             width,
             height,
-            3,
+            ColorDepth::Rgb8,
         ) {
             img.scale(w, h, false, true);
             img.draw(x, y, w, h);

--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -17,6 +17,20 @@ pub enum LabelType {
     Embossed,
 }
 
+/// Defines the color depth for drawing and rgb images
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum ColorDepth {
+    /// Luminance/grayscale
+    L8 = 1,
+    /// Luminance with Alpha channel
+    La8 = 2,
+    /// RGB888
+    Rgb8 = 3,
+    /// RGBA8888 with Alpha channel
+    Rgba8 = 4,
+}
+
 /// Defines the frame types which can be set using the set_frame() and set_down_frame() methods
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/fltk/src/image.rs
+++ b/fltk/src/image.rs
@@ -584,14 +584,8 @@ impl RgbImage {
     /// Initializes a new raw RgbImage, copies the data and handles its lifetime
     /// If you need to work with RGB data,
     /// it's suggested to use the Image crate https://crates.io/crates/image
-    pub fn new(data: &[u8], w: u32, h: u32, depth: u32) -> Result<RgbImage, FltkError> {
-        if depth > 4 {
-            return Err(FltkError::Internal(FltkErrorKind::ImageFormatError));
-        }
-        let mut sz = w * h;
-        if depth > 0 {
-            sz *= depth;
-        }
+    pub fn new(data: &[u8], w: u32, h: u32, depth: ColorDepth) -> Result<RgbImage, FltkError> {
+        let sz = w * h * depth as u32;
         if sz > data.len() as u32 {
             return Err(FltkError::Internal(FltkErrorKind::ImageFormatError));
         }
@@ -621,15 +615,9 @@ impl RgbImage {
         data: &[u8],
         w: u32,
         h: u32,
-        depth: u32,
+        depth: ColorDepth,
     ) -> Result<RgbImage, FltkError> {
-        if depth > 4 {
-            return Err(FltkError::Internal(FltkErrorKind::ImageFormatError));
-        }
-        let mut sz = w * h;
-        if depth > 0 {
-            sz *= depth;
-        }
+        let sz = w * h * depth as u32;
         if sz > data.len() as u32 {
             return Err(FltkError::Internal(FltkErrorKind::ImageFormatError));
         }

--- a/fltk/src/lib.rs
+++ b/fltk/src/lib.rs
@@ -32,6 +32,7 @@
 //! ```toml
 //! [dependencies]
 //! fltk = { version = "^0.15", git = "https://github.com/MoAlyousef/fltk-rs" }
+//! ```
 //!
 //! The library is automatically built and statically linked to your binary.
 //!
@@ -40,7 +41,7 @@
 //! An example hello world application:
 //!
 //! ```no_run
-//! use fltk::{app::*, window::*};
+//! use fltk::{app, window::*};
 //! let app = app::App::default();
 //! let mut wind = Window::new(100, 100, 400, 300, "Hello from rust");
 //! wind.end();
@@ -117,10 +118,11 @@
 //!
 //!     while app.wait() {
 //!         let label: i32 = frame.label().parse().unwrap();
-//!         match r.recv() {
-//!             Some(Message::Increment) => frame.set_label(&(label + 1).to_string()),
-//!             Some(Message::Decrement) => frame.set_label(&(label - 1).to_string()),
-//!             None => (),
+//!         if let Some(msg) = r.recv() {
+//!             match msg {
+//!                 Message::Increment => frame.set_label(&(label + 1).to_string()),
+//!                 Message::Decrement => frame.set_label(&(label - 1).to_string()),
+//!             }
 //!         }
 //!     }
 //! ```
@@ -182,8 +184,10 @@
 //! For Debian-based GUI distributions, that means running:
 //! ```ignored
 //! $ sudo apt-get install libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libpango1.0-dev libpng-dev libgl1-mesa-dev libglu1-mesa-dev
+//! ```
 //! ```ignored
 //! For RHEL-based GUI distributions, that means running:
+//! ```
 //! ```ignored
 //! $ sudo yum groupinstall "X Software Development" && yum install pango-devel libXinerama-devel libpng-devel
 //! ```

--- a/fltk/src/prelude.rs
+++ b/fltk/src/prelude.rs
@@ -1093,7 +1093,7 @@ pub unsafe trait ImageExt {
     /// Gets the image's data height
     fn data_h(&self) -> u32;
     /// Gets the image's depth
-    fn depth(&self) -> u32;
+    fn depth(&self) -> ColorDepth;
     /// Gets the image's line data size
     fn ld(&self) -> u32;
     /// Greys the image


### PR DESCRIPTION
- [BREAKING] RgbImage::new() and draw::draw_image() take a ColorDepth enum instead of an int.
- [BREAKING] Remove app::delay().
- [BREAKING] Remove image related LabelType values.
- [BREAKING] Change iconsize and set_iconsize to icon_size and set_icon_size.
- [BREAKING] BrowserExt::topline, middleline and bottomline converted to snake case.
- [BREAKING] app::wait_for returns a Result<bool, FltkError>.
- Fix temp file creation when lacking TMPDIR env variable on some systems.
- Fix doc tests.
- Add tests directory.
- Update FLTK and cfltk.