### PR TITLE
0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## [0.15.1] - 2021-02-20
+## [0.15.2] - 2021-02-22
 ### Changes
 - [BREAKING] RgbImage::new() and draw::draw_image() take a ColorDepth enum instead of an int.
 - [BREAKING] Remove app::delay().

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,3 +1,6 @@
 # Roadmap
 
+## 0.16
+- Use stronger typing for handled events in the WidgetBase::handle method. 
+
 

--- a/fltk/src/draw.rs
+++ b/fltk/src/draw.rs
@@ -802,15 +802,9 @@ pub fn draw_image(
     y: i32,
     w: i32,
     h: i32,
-    depth: u32,
+    depth: ColorDepth,
 ) -> Result<(), FltkError> {
-    if depth > 4 {
-        return Err(FltkError::Internal(FltkErrorKind::ImageFormatError));
-    }
-    let mut sz = (w * h) as usize;
-    if depth > 0 {
-        sz *= depth as usize;
-    }
+    let sz = (w * h * depth as i32) as usize;
     if sz > data.len() {
         return Err(FltkError::Internal(FltkErrorKind::ImageFormatError));
     }


### PR DESCRIPTION
- [BREAKING] RgbImage::new() and draw::draw_image() take a ColorDepth enum instead of an int.
- [BREAKING] Remove app::delay().
- [BREAKING] Remove image related LabelType values.
- [BREAKING] Change iconsize and set_iconsize to icon_size and set_icon_size.
- [BREAKING] BrowserExt::topline, middleline and bottomline converted to snake case.
- [BREAKING] app::wait_for returns a Result<bool, FltkError>.
- Fix temp file creation when lacking TMPDIR env variable on some systems.
- Fix doc tests.
- Add tests directory.
- Update FLTK and cfltk.