### PR TITLE
0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,8 @@
 
 ## [0.16.1] - 2021-03-22
 ### Changes
-- Fix Fl_RGB_Image allocation.
-
-## [0.16.0] - 2021-03-22
-### Changes
 - [BREAKING] Remove image conversion code.
+- Fix Fl_RGB_Image allocation.
 - Refactor build script.
 - Enable the fltk-bundled feature on a system path using the CFLTK_BUNDLE_DIR env variable.
 - Enable the fltk-bundled feature on a user-defined url using CFLTK_BUNDLE_URL env var.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## [0.16.1] - 2021-03-22
+### Changes
+- Fix Fl_RGB_Image allocation.
+
 ## [0.16.0] - 2021-03-22
 ### Changes
 - [BREAKING] Remove image conversion code.


### PR DESCRIPTION
- [BREAKING] Remove image conversion code.
- Fix Fl_RGB_Image allocation.
- Refactor build script.
- Enable the fltk-bundled feature on a system path using the CFLTK_BUNDLE_DIR env variable.
- Enable the fltk-bundled feature on a user-defined url using CFLTK_BUNDLE_URL env var.
- Add app::set_font_size() to set the global font size of the app.
- Add Slider (and Scrollbar) slider_size setter and getter.
- Add Slider (and Scrollbar) slider_frame setter and getter.