### PR TITLE
0.16.1

### DIFF
--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-sys/Cargo.toml
+++ b/fltk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-sys"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 build = "build.rs"
 edition = "2018"

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -17,8 +17,8 @@ name = "fltk"
 path = "src/lib.rs"
 
 [dependencies]
-fltk-sys = { path = "../fltk-sys", version = "=0.16.0" }
-fltk-derive = { path = "../fltk-derive", version = "=0.16.0" }
+fltk-sys = { path = "../fltk-sys", version = "=0.16.1" }
+fltk-derive = { path = "../fltk-derive", version = "=0.16.1" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 gl_loader = { version = "^0.1.2", optional = true }


### PR DESCRIPTION
- [BREAKING] Remove image conversion code.
- Fix Fl_RGB_Image allocation.
- Refactor build script.
- Enable the fltk-bundled feature on a system path using the CFLTK_BUNDLE_DIR env variable.
- Enable the fltk-bundled feature on a user-defined url using CFLTK_BUNDLE_URL env var.
- Add app::set_font_size() to set the global font size of the app.
- Add Slider (and Scrollbar) slider_size setter and getter.
- Add Slider (and Scrollbar) slider_frame setter and getter.