### PR TITLE
1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,7 @@
 # Changelog
 
 
-## [1.0.1] - 2021-04-19
-- Add MenuItem::children().
-- Relax mutability requirement for MenuItem::next() and at().
-- Add check on WidgetExt::label().
-
-## [1.0.0] - 2021-04-18
+## [1.0.1] - 2021-04-18
 - [BREAKING] Importing fltk::* no longer auto-imports the prelude nor enums modules.
 - [BREAKING] Importing widgets no longer auto-imports the prelude nor enums modules.
 - [BREAKING] Replace set_callback, handle, draw, draw_cell with their overloads.
@@ -21,6 +16,9 @@
 - Add a Column and Row widgets which support auto_layout by default, but require that widgets be added using add().
 - Add ValueInput::soft and set_soft methods.
 - Add WindowExt::set_cursor_image() and default_cursor().
+- Add MenuItem::children().
+- Relax mutability requirement for MenuItem::next() and at().
+- Add check on WidgetExt::label().
 
 ## [0.16.5] - 2021-04-10
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## [1.0.1] - 2021-04-19
+- Add MenuItem::children().
+- Relax mutability requirement for MenuItem::next() and at().
+- Add check on WidgetExt::label().
+
 ## [1.0.0] - 2021-04-18
 - [BREAKING] Importing fltk::* no longer auto-imports the prelude nor enums modules.
 - [BREAKING] Importing widgets no longer auto-imports the prelude nor enums modules.

--- a/fltk-derive/Cargo.toml
+++ b/fltk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-derive"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"

--- a/fltk-derive/src/widget.rs
+++ b/fltk-derive/src/widget.rs
@@ -430,7 +430,12 @@ pub fn impl_widget_trait(ast: &DeriveInput) -> TokenStream {
             fn label(&self) -> String {
                 assert!(!self.was_deleted());
                 unsafe {
-                    CStr::from_ptr(#label(self.inner) as *mut raw::c_char).to_string_lossy().to_string()
+                    let ptr = #label(self.inner) as *mut raw::c_char;
+                    if ptr.is_null() {
+                        String::from("")
+                    } else {
+                        CStr::from_ptr(ptr).to_string_lossy().to_string()
+                    }
                 }
             }
 

--- a/fltk-derive/src/window.rs
+++ b/fltk-derive/src/window.rs
@@ -374,8 +374,6 @@ pub fn impl_window_trait(ast: &DeriveInput) -> TokenStream {
                 assert!(!self.was_deleted());
                 unsafe {
                     image.increment_arc();
-                    assert!(image.w() == image.data_w() as i32);
-                    assert!(image.h() == image.data_h() as i32);
                     #set_cursor_image(self.inner, image.as_image_ptr() as _, hot_x, hot_y)
                 }
             }

--- a/fltk/Cargo.toml
+++ b/fltk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["MoAlyousef <mohammed.alyousef@neurosrg.com>"]
 edition = "2018"
 description = "Rust bindings for the FLTK GUI library"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fltk-sys = { path = "../fltk-sys", version = "=1.0.0" }
-fltk-derive = { path = "../fltk-derive", version = "=1.0.0" }
+fltk-derive = { path = "../fltk-derive", version = "=1.0.1" }
 lazy_static = "^1.4.0"
 bitflags = "^1.2.1"
 gl_loader = { version = "^0.1.2", optional = true }

--- a/fltk/examples/custom_dial.rs
+++ b/fltk/examples/custom_dial.rs
@@ -14,7 +14,8 @@ impl MyDial {
     pub fn new(x: i32, y: i32, w: i32, h: i32, label: &'static str) -> Self {
         let value = Rc::from(RefCell::from(0));
         let mut main_wid = frame::Frame::new(x, y, w, h, label).with_align(Align::Top);
-        let mut value_frame = frame::Frame::new(main_wid.x(), main_wid.y() + 80, main_wid.w(), 40, "0");
+        let mut value_frame =
+            frame::Frame::new(main_wid.x(), main_wid.y() + 80, main_wid.w(), 40, "0");
         value_frame.set_label_size(26);
         let value_c = value.clone();
         main_wid.draw(move |w| {
@@ -39,7 +40,11 @@ impl MyDial {
                 360.,
             );
         });
-        Self { main_wid, value, value_frame }
+        Self {
+            main_wid,
+            value,
+            value_frame,
+        }
     }
     pub fn value(&self) -> i32 {
         *self.value.borrow()

--- a/fltk/examples/custom_popup.rs
+++ b/fltk/examples/custom_popup.rs
@@ -1,0 +1,95 @@
+use fltk::{enums::*, prelude::*, *};
+use std::cell::RefCell;
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
+
+pub struct PopupButton {
+    but: button::Button,
+}
+
+impl PopupButton {
+    pub fn new(label: &str) -> Self {
+        let mut but = button::Button::default().with_label(label);
+        but.set_frame(FrameType::FlatBox);
+        but.handle(|b, ev| match ev {
+            Event::Enter => {
+                b.set_color(Color::Blue);
+                b.top_window().unwrap().redraw();
+                true
+            }
+            Event::Leave => {
+                b.set_color(Color::BackGround);
+                b.top_window().unwrap().redraw();
+                true
+            }
+            _ => false,
+        });
+        Self { but }
+    }
+}
+
+impl Deref for PopupButton {
+    type Target = button::Button;
+
+    fn deref(&self) -> &Self::Target {
+        &self.but
+    }
+}
+
+impl DerefMut for PopupButton {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.but
+    }
+}
+
+pub struct MyPopup {
+    win: window::Window,
+    val: Rc<RefCell<String>>,
+}
+
+impl MyPopup {
+    pub fn new(choices: &[&str]) -> Self {
+        let val = Rc::from(RefCell::from(String::from("")));
+        let mut win = window::Window::default().with_size(100, 100);
+        let mut pack = group::Pack::default().size_of_parent();
+        pack.set_frame(FrameType::ThinUpFrame);
+        pack.set_spacing(5);
+        win.set_border(false);
+        win.make_modal(true);
+        win.end();
+        for choice in choices {
+            let mut but = PopupButton::new(choice);
+            but.set_callback({
+                let mut win = win.clone();
+                let val = val.clone();
+                move |b| {
+                    *val.borrow_mut() = b.label();
+                    win.hide();
+                }
+            });
+            pack.add(&*but);
+        }
+        pack.auto_layout();
+        Self { win, val }
+    }
+    pub fn popup(&mut self, x: i32, y: i32) -> String {
+        self.win.redraw();
+        self.win.show();
+        self.win.set_pos(x, y);
+        while self.win.shown() {
+            app::wait();
+        }
+        self.val.borrow().to_string()
+    }
+}
+
+fn main() {
+    let app = app::App::default();
+    let mut win = window::Window::default().with_size(400, 300);
+    let mut but = button::Button::new(160, 200, 80, 40, "Click me");
+    win.end();
+    win.show();
+    let mut menu = MyPopup::new(&["1st item", "2nd item", "3rd Item"]);
+    but.set_callback(move |_| println!("{}", menu.popup(app::event_x(), app::event_y())));
+    app.run().unwrap();
+}

--- a/fltk/examples/custom_popup.rs
+++ b/fltk/examples/custom_popup.rs
@@ -14,12 +14,12 @@ impl PopupButton {
         but.handle(|b, ev| match ev {
             Event::Enter => {
                 b.set_color(Color::Blue);
-                b.top_window().unwrap().redraw();
+                b.redraw();
                 true
             }
             Event::Leave => {
                 b.set_color(Color::BackGround);
-                b.top_window().unwrap().redraw();
+                b.redraw();
                 true
             }
             _ => false,
@@ -53,12 +53,13 @@ impl MyPopup {
         let mut win = window::Window::default().with_size(100, 100);
         let mut pack = group::Pack::default().size_of_parent();
         pack.set_frame(FrameType::ThinUpFrame);
-        pack.set_spacing(5);
+        pack.set_color(Color::Black);
         win.set_border(false);
         win.make_modal(true);
         win.end();
         for choice in choices {
             let mut but = PopupButton::new(choice);
+            but.clear_visible_focus();
             but.set_callback({
                 let mut win = win.clone();
                 let val = val.clone();

--- a/fltk/examples/custom_popup.rs
+++ b/fltk/examples/custom_popup.rs
@@ -74,9 +74,9 @@ impl MyPopup {
         Self { win, val }
     }
     pub fn popup(&mut self, x: i32, y: i32) -> String {
-        self.win.redraw();
         self.win.show();
         self.win.set_pos(x, y);
+        self.win.redraw();
         while self.win.shown() {
             app::wait();
         }
@@ -91,6 +91,6 @@ fn main() {
     win.end();
     win.show();
     let mut menu = MyPopup::new(&["1st item", "2nd item", "3rd Item"]);
-    but.set_callback(move |_| println!("{}", menu.popup(app::event_x(), app::event_y())));
+    but.set_callback(move |_| println!("{}", menu.popup(app::event_x_root(), app::event_y_root())));
     app.run().unwrap();
 }

--- a/fltk/examples/shapedwindow.rs
+++ b/fltk/examples/shapedwindow.rs
@@ -36,9 +36,6 @@ impl ShapedWindow {
     pub fn show(&mut self) {
         self.wind.show();
     }
-    pub fn set_cursor_image(&mut self, image: image::RgbImage) {
-        self.wind.set_cursor_image(image, 0, 0);
-    }
 }
 
 fn main() {
@@ -52,8 +49,7 @@ fn main() {
     let pattern = image::RgbImage::new(&pattern, 500, 500, enums::ColorDepth::Rgb8).unwrap();
     let app = app::App::default();
     let mut win = ShapedWindow::default();
-    win.set_image(Some(pattern.clone()));
-    win.set_cursor_image(pattern);
+    win.set_image(Some(pattern));
     win.show();
     app.run().unwrap();
 }

--- a/fltk/src/menu.rs
+++ b/fltk/src/menu.rs
@@ -254,29 +254,33 @@ impl MenuItem {
     }
 
     /// Get the next menu item
-    pub fn next(&mut self, idx: i32) -> Option<MenuItem> {
+    pub fn next(&self, idx: i32) -> Option<MenuItem> {
         assert!(!self.was_deleted());
         unsafe {
             let ptr = Fl_Menu_Item_next(self.inner, idx as i32);
             if ptr.is_null() {
-                None
-            } else {
-                Some(MenuItem { inner: ptr })
+                return None;
             }
+            let label_ptr = Fl_Menu_Item_label(ptr);
+            if label_ptr.is_null() {
+                return None;
+            }
+            Some(MenuItem { inner: ptr })
         }
+    }
+
+    /// Get children of MenuItem
+    pub fn children(&self) -> i32 {
+        let mut i = 0;
+        while let Some(_item) = self.next(i) {
+            i += 1;
+        }
+        i
     }
 
     /// Get the menu item at `idx`
     pub fn at(&self, idx: i32) -> Option<MenuItem> {
-        assert!(!self.was_deleted());
-        unsafe {
-            let ptr = Fl_Menu_Item_next(self.inner, idx as i32);
-            if ptr.is_null() {
-                None
-            } else {
-                Some(MenuItem { inner: ptr })
-            }
-        }
+        self.next(idx)
     }
 
     /// Get the user data
@@ -377,7 +381,7 @@ impl IntoIterator for MenuItem {
     type Item = MenuItem;
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
-    fn into_iter(mut self) -> Self::IntoIter {
+    fn into_iter(self) -> Self::IntoIter {
         let mut v: Vec<MenuItem> = vec![];
         let mut i = 0;
         while let Some(item) = self.next(i) {


### PR DESCRIPTION
- [BREAKING] Importing fltk::* no longer auto-imports the prelude nor enums modules.
- [BREAKING] Importing widgets no longer auto-imports the prelude nor enums modules.
- [BREAKING] Replace set_callback, handle, draw, draw_cell with their overloads.
- [BREAKING] Widgets take a `&'static str` for a label when initialized. To use dynamic labels, use set_label or with_label.
- [BREAKING] Replace TableExt::visible_cells and get_selection with their easier overloads.
- [BREAKING] Rename InputChoice::set_value2 to set_value_index.
- [BREAKING] Take i32 where FLTK expects i32.
- [BREAKING] Rename WidgetType::to_int() to to_i32().
- [BREAKING] app::event_dx() and event_dy() return an app::MouseWheel instead of i32.
- [BREAKING] enums::Mouse moved to app::MouseButton.
- [BREAKING] Move enums::TextCursor to text::Cursor.
- Add a Column and Row widgets which support auto_layout by default, but require that widgets be added using add().
- Add ValueInput::soft and set_soft methods.
- Add WindowExt::set_cursor_image() and default_cursor().
- Add MenuItem::children().
- Relax mutability requirement for MenuItem::next() and at().
- Add check on WidgetExt::label().