### PR TITLE
New shortcuts: Meta, Command and Control

### DIFF
--- a/fltk/src/enums.rs
+++ b/fltk/src/enums.rs
@@ -650,6 +650,20 @@ bitflags! {
         const Ctrl = 0x0004_0000;
         /// Alt
         const Alt = 0x0008_0000;
+        /// Meta
+        const Meta = 0x0040_0000;
+        /// Command (Meta for macOS, Ctrl for other systems)
+        const Command = if cfg!(target_os = "macos") {
+            Shortcut::Meta.bits
+        } else {
+            Shortcut::Ctrl.bits
+        };
+        /// Control (Ctrl for macOS, Meta for other systems)
+        const Control = if cfg!(target_os = "macos") {
+            Shortcut::Ctrl.bits
+        } else {
+            Shortcut::Meta.bits
+        };
     }
 }
 


### PR DESCRIPTION
This adds the Meta shortcut ([see FLTK documentation](https://www.fltk.org/doc-1.4/Enumerations_8H.html#a2c50b1b00111f992d5d49f07c9cee22a)) as well as the Command and Control shortcuts ([see FLTK documentation](https://www.fltk.org/doc-1.4/platform__types_8h.html#a5d4011c75b1fe25d9ef36e8ae9e2995c)), which are quite helpful for working with macOS.